### PR TITLE
Add healthcheck for localstack resources

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -1,4 +1,3 @@
-version: '3.4'
 services:
   localstack:
     image: localstack/localstack:3.0.2
@@ -16,10 +15,10 @@ services:
       - '${TMPDIR:-/tmp}/localstack:/var/lib/localstack'
       - ./compose/start-localstack.sh:/etc/localstack/init/ready.d/start-localstack.sh
     healthcheck:
-      test: ['CMD', 'curl', 'localhost:4566']
+      test: cat /tmp/ready
       interval: 5s
       start_period: 5s
-      retries: 3
+      retries: 10
 
   # redis:
   #   image: redis:7.2.3-alpine3.18

--- a/compose/start-localstack.sh
+++ b/compose/start-localstack.sh
@@ -15,4 +15,16 @@ export AWS_SECRET_ACCESS_KEY=test
 # aws --endpoint-url=http://localhost:4566 sqs create-queue --queue-name my-queue
 
 # SQS queues
-aws --endpoint-url=$ENDPOINT_URL sqs create-queue --queue-name data_events
+aws --endpoint-url=http://localhost:4566 sqs create-queue --queue-name data_events
+
+function is_ready() {
+    aws --endpoint-url=http://localhost:4566 sqs get-queue-url --queue-name data_events || return 1
+    return 0
+}
+
+while ! is_ready; do
+    echo "Waiting until ready"
+    sleep 1
+done
+
+touch /tmp/ready


### PR DESCRIPTION
Localstack simulates creating resources asynchronously like AWS does, so we have to poll until the resources are ready to be used.