### PR TITLE
Configure dependabot to use classic PAT (as this is all it supports when private nuget repos are being used)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,11 @@
 version: 2
 
+registries:
+  defra:
+    type: nuget-feed
+    url: https://nuget.pkg.github.com/DEFRA/index.json
+    token: ${{ secrets.DEPENDABOT_PAT }}
+
 updates:
   - package-ecosystem: nuget
     directory: /
@@ -19,6 +25,7 @@ updates:
           - "minor"
     allow:
       - dependency-type: direct
+    registries: "*"
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
As per PR title.