### PR TITLE
Ensure correct decision is seen in relation to document code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -272,3 +272,5 @@ openapi.json
 
 *.received.*
 /src/Deriver/Properties/.env.local
+
+.env

--- a/src/Deriver/Decisions/ClearanceDecisionBuilder.cs
+++ b/src/Deriver/Decisions/ClearanceDecisionBuilder.cs
@@ -89,7 +89,7 @@ public static class ClearanceDecisionBuilder
         if (maxDecisionResult.DecisionCode == DecisionCode.X00)
         {
             var chedType = MapToChedType(item.Documents?[0].DocumentCode!);
-            var chedNumbers = string.Join(',', item.Documents!.Select(x => x.DocumentReference));
+            var chedNumbers = string.Join(", ", item.Documents!.Select(x => x.DocumentReference?.Value));
 
             if (!reasons.Any())
             {

--- a/tests/Deriver.Tests/Decisions/ClearanceDecisionBuilderTests.BuildClearanceDecision_WithReasons.verified.txt
+++ b/tests/Deriver.Tests/Decisions/ClearanceDecisionBuilderTests.BuildClearanceDecision_WithReasons.verified.txt
@@ -22,7 +22,7 @@
           CheckCode: 9115,
           DecisionCode: X00,
           DecisionReasons: [
-            A Customs Declaration has been submitted however no matching Chedpp(s) have been submitted to Port Health (for Chedpp number(s) Defra.TradeImportsDataApi.Domain.CustomsDeclaration.ImportDocumentReference,Defra.TradeImportsDataApi.Domain.CustomsDeclaration.ImportDocumentReference,Defra.TradeImportsDataApi.Domain.CustomsDeclaration.ImportDocumentReference). Please correct the Chedpp number(s) entered on your customs declaration.
+            A Customs Declaration has been submitted however no matching Chedpp(s) have been submitted to Port Health (for Chedpp number(s) fixed-4, fixed-5, fixed-6). Please correct the Chedpp number(s) entered on your customs declaration.
           ]
         }
       ]
@@ -34,7 +34,7 @@
           CheckCode: 9115,
           DecisionCode: X00,
           DecisionReasons: [
-            A Customs Declaration has been submitted however no matching Chedpp(s) have been submitted to Port Health (for Chedpp number(s) Defra.TradeImportsDataApi.Domain.CustomsDeclaration.ImportDocumentReference,Defra.TradeImportsDataApi.Domain.CustomsDeclaration.ImportDocumentReference,Defra.TradeImportsDataApi.Domain.CustomsDeclaration.ImportDocumentReference). Please correct the Chedpp number(s) entered on your customs declaration.
+            A Customs Declaration has been submitted however no matching Chedpp(s) have been submitted to Port Health (for Chedpp number(s) fixed-7, fixed-8, fixed-9). Please correct the Chedpp number(s) entered on your customs declaration.
           ]
         }
       ]

--- a/tests/Deriver.Tests/Decisions/ClearanceDecisionBuilderTests.cs
+++ b/tests/Deriver.Tests/Decisions/ClearanceDecisionBuilderTests.cs
@@ -55,7 +55,9 @@ public class ClearanceDecisionBuilderTests
     [Fact]
     public async Task BuildClearanceDecision_WithReasons()
     {
-        var customsDeclaration = CustomsDeclarationResponseFixtures.CustomsDeclarationResponseFixture();
+        var customsDeclaration = CustomsDeclarationResponseFixtures.CustomsDeclarationResponseFixture(
+            documentReferencePrefix: "fixed"
+        );
         customsDeclaration.ClearanceRequest!.ExternalCorrelationId = "correlationId";
         customsDeclaration.ClearanceRequest!.ExternalVersion = 22;
         var decisionResult = new DecisionResult();

--- a/tests/Directory.Build.targets
+++ b/tests/Directory.Build.targets
@@ -1,0 +1,12 @@
+<Project>
+  <ItemGroup Condition="'@(PackageReference-&gt;AnyHaveMetadataValue('Identity', 'AutoFixture'))' == 'True'">
+    <!-- AutoFixture@4.18.1 -->
+    <!-- https://github.com/advisories/GHSA-7jgj-8wvc-jh57 -->
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+  </ItemGroup>
+  <ItemGroup Condition="'@(PackageReference-&gt;AnyHaveMetadataValue('Identity', 'AutoFixture'))' == 'True'">
+    <!-- AutoFixture@4.18.1 -->
+    <!-- https://github.com/advisories/GHSA-cmhx-cq75-c4mj -->
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
+  </ItemGroup>
+</Project>

--- a/tests/TestFixtures/CustomsDeclarationResponseFixtures.cs
+++ b/tests/TestFixtures/CustomsDeclarationResponseFixtures.cs
@@ -5,18 +5,28 @@ namespace Defra.TradeImportsDecisionDeriver.TestFixtures;
 
 public static class CustomsDeclarationResponseFixtures
 {
-    public static CustomsDeclarationResponse CustomsDeclarationResponseFixture(string mrn = "mrn123")
+    public static CustomsDeclarationResponse CustomsDeclarationResponseFixture(
+        string mrn = "mrn123",
+        string? documentReferencePrefix = null
+    )
     {
         var fixture = new Fixture();
         fixture.Customize<DateOnly>(o => o.FromFactory((DateTime dt) => DateOnly.FromDateTime(dt)));
 
         var response = fixture.Build<CustomsDeclarationResponse>().With(x => x.MovementReferenceNumber, mrn).Create();
 
+        int documentReferenceCount = 1;
+
         foreach (var commodity in response.ClearanceRequest?.Commodities!)
         {
             foreach (var document in commodity.Documents!)
             {
                 document.DocumentCode = "C640";
+
+                if (document.DocumentReference != null && documentReferencePrefix is not null)
+                    document.DocumentReference.Value = $"{documentReferencePrefix}-{documentReferenceCount}";
+
+                documentReferenceCount++;
             }
         }
 


### PR DESCRIPTION
Previously, the .NET type name was being rendered. 

This PR fixes the output so the value is included instead.

An additional build props redirect file has been included in the test folder only as Autofixture still references other packages with security vulnerabilities. The redirect file ensures the transient dependencies are updated.