### PR TITLE
Concurrency and logging tweaks

### DIFF
--- a/src/Deriver/Consumers/ClearanceRequestConsumer.cs
+++ b/src/Deriver/Consumers/ClearanceRequestConsumer.cs
@@ -71,9 +71,8 @@ public class ClearanceRequestConsumer(
         }
 
         logger.LogInformation(
-            "Decision Derived: {Decision} with {DecisionContext}",
-            JsonSerializer.Serialize(decisionResult, _jsonSerializerOptions),
-            JsonSerializer.Serialize(decisionContext, _jsonSerializerOptions)
+            "Decision Derived: {Decision}",
+            JsonSerializer.Serialize(decisionResult, _jsonSerializerOptions)
         );
         await PersistDecision(cancellationToken, clearanceRequest, decisionResult);
     }

--- a/src/Deriver/Consumers/ImportPreNotificationConsumer.cs
+++ b/src/Deriver/Consumers/ImportPreNotificationConsumer.cs
@@ -58,9 +58,8 @@ public class ImportPreNotificationConsumer(
         }
 
         logger.LogInformation(
-            "Decision Derived: {Decision} with {DecisionContext}",
-            JsonSerializer.Serialize(decisionResult, _jsonSerializerOptions),
-            JsonSerializer.Serialize(decisionContext, _jsonSerializerOptions)
+            "Decision Derived: {Decision}}",
+            JsonSerializer.Serialize(decisionResult, _jsonSerializerOptions)
         );
         await PersistDecisions(cancellationToken, clearanceRequests, decisionResult);
     }

--- a/src/Deriver/Consumers/ImportPreNotificationConsumer.cs
+++ b/src/Deriver/Consumers/ImportPreNotificationConsumer.cs
@@ -58,7 +58,7 @@ public class ImportPreNotificationConsumer(
         }
 
         logger.LogInformation(
-            "Decision Derived: {Decision}}",
+            "Decision Derived: {Decision}",
             JsonSerializer.Serialize(decisionResult, _jsonSerializerOptions)
         );
         await PersistDecisions(cancellationToken, clearanceRequests, decisionResult);

--- a/src/Deriver/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Deriver/Extensions/ServiceCollectionExtensions.cs
@@ -82,7 +82,7 @@ public static class ServiceCollectionExtensions
                 );
             });
 
-            mbb.Consume<JsonElement>(x => x.WithConsumer<ConsumerMediator>().Queue(queueName));
+            mbb.Consume<JsonElement>(x => x.WithConsumer<ConsumerMediator>().Queue(queueName).Instances(20));
 
             mbb.AddJsonSerializer();
         });

--- a/src/Deriver/appsettings.json
+++ b/src/Deriver/appsettings.json
@@ -13,8 +13,7 @@
       "Default": "Information",
       "Override": {
         "Microsoft": "Information",
-        "System": "Information",
-        "Amazon.CloudWatch.EMF": "Debug"
+        "System": "Information"
       }
     },
     "WriteTo": [


### PR DESCRIPTION
1. Updated concurrency count to 20 to match the import processor
2. Stopped logging EMF debug messages
3. Only log the decision result, as the decision context was causing errors to clog the logs
