### PR TITLE
CDMS-655: Bump Data Api package version

### DIFF
--- a/src/Deriver/Deriver.csproj
+++ b/src/Deriver/Deriver.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Defra.TradeImportsDataApi.Api.Client" Version="0.18.0-pr-83.492" />
+    <PackageReference Include="Defra.TradeImportsDataApi.Api.Client" Version="0.20.0-pr-98.564" />
     <PackageReference Include="Elastic.CommonSchema.Serilog" Version="8.12.3" />
     <PackageReference Include="Elastic.Serilog.Enrichers.Web" Version="8.12.3" />
     <PackageReference Include="Microsoft.AspNetCore.HeaderPropagation" Version="9.0.4" />


### PR DESCRIPTION
This bumps the client version to ensure there are no build failures with the change of int to string for the FinalState value.