### PR TITLE
Update to client version where list endpoints return an object with nested list instead of a raw list

### DIFF
--- a/src/Deriver/Consumers/ClearanceRequestConsumer.cs
+++ b/src/Deriver/Consumers/ClearanceRequestConsumer.cs
@@ -3,7 +3,6 @@ using System.Text.Json.Serialization;
 using Defra.TradeImportsDataApi.Api.Client;
 using Defra.TradeImportsDataApi.Domain.CustomsDeclaration;
 using Defra.TradeImportsDataApi.Domain.Events;
-using Defra.TradeImportsDataApi.Domain.Ipaffs;
 using Defra.TradeImportsDecisionDeriver.Deriver.Decisions;
 using Defra.TradeImportsDecisionDeriver.Deriver.Decisions.Comparers;
 using Defra.TradeImportsDecisionDeriver.Deriver.Matching;
@@ -43,17 +42,14 @@ public class ClearanceRequestConsumer(
             return;
         }
 
-        var notificationResponses = await apiClient.GetImportPreNotificationsByMrn(
+        var notificationResponse = await apiClient.GetImportPreNotificationsByMrn(
             message.ResourceId,
             cancellationToken
         );
 
-        var preNotifications = new List<ImportPreNotification>();
-
-        if (notificationResponses is not null)
-        {
-            preNotifications = notificationResponses.Select(x => x.ImportPreNotification).ToList();
-        }
+        var preNotifications = notificationResponse
+            .ImportPreNotifications.Select(x => x.ImportPreNotification)
+            .ToList();
 
         var decisionContext = new DecisionContext(
             preNotifications.Select(x => x.ToDecisionImportPreNotification()).ToList(),

--- a/src/Deriver/Consumers/ImportPreNotificationConsumer.cs
+++ b/src/Deriver/Consumers/ImportPreNotificationConsumer.cs
@@ -105,13 +105,8 @@ public class ImportPreNotificationConsumer(
     {
         var customsDeclarations = await apiClient.GetCustomsDeclarationsByChedId(chedId, cancellationToken);
 
-        if (customsDeclarations == null)
-        {
-            return [];
-        }
-
         return customsDeclarations
-            .Where(x => x.ClearanceRequest is not null)
+            .CustomsDeclarations.Where(x => x.ClearanceRequest is not null)
             .Where(x => x.Finalisation is null)
             .Select(x => new ClearanceRequestWrapper(x.MovementReferenceNumber, x.ClearanceRequest!))
             .ToList();
@@ -125,18 +120,16 @@ public class ImportPreNotificationConsumer(
             async (mrn, cancellationToken) =>
             {
                 var apiResponse = await apiClient.GetImportPreNotificationsByMrn(mrn, cancellationToken);
-                if (apiResponse != null)
-                {
-                    foreach (
-                        var notificationResponse in apiResponse.Where(notificationResponse =>
-                            !notifications.Exists(x =>
-                                x.ReferenceNumber == notificationResponse.ImportPreNotification.ReferenceNumber
-                            )
+
+                foreach (
+                    var notificationResponse in apiResponse.ImportPreNotifications.Where(notificationResponse =>
+                        !notifications.Exists(x =>
+                            x.ReferenceNumber == notificationResponse.ImportPreNotification.ReferenceNumber
                         )
                     )
-                    {
-                        notifications.Add(notificationResponse.ImportPreNotification);
-                    }
+                )
+                {
+                    notifications.Add(notificationResponse.ImportPreNotification);
                 }
             }
         );

--- a/src/Deriver/Deriver.csproj
+++ b/src/Deriver/Deriver.csproj
@@ -15,7 +15,7 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Defra.TradeImportsDataApi.Api.Client" Version="0.22.0" />
+    <PackageReference Include="Defra.TradeImportsDataApi.Api.Client" Version="0.25.0-pr-113.653" />
     <PackageReference Include="Elastic.CommonSchema.Serilog" Version="8.12.3" />
     <PackageReference Include="Elastic.Serilog.Enrichers.Web" Version="8.12.3" />
     <PackageReference Include="Microsoft.AspNetCore.HeaderPropagation" Version="9.0.5" />

--- a/tests/Deriver.IntegrationTests/Consumers/CustomsDeclarationsConsumerTests.cs
+++ b/tests/Deriver.IntegrationTests/Consumers/CustomsDeclarationsConsumerTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using Amazon.SQS.Model;
+using Defra.TradeImportsDataApi.Api.Client;
 using Defra.TradeImportsDataApi.Domain.Events;
 using Defra.TradeImportsDecisionDeriver.Deriver.Extensions;
 using Defra.TradeImportsDecisionDeriver.Deriver.IntegrationTests.Clients;
@@ -68,7 +69,7 @@ public class CustomsDeclarationsConsumerTests(ITestOutputHelper output, WireMock
                         .WithPath($"/customs-declarations/{customsDeclaration.ResourceId}/import-pre-notifications")
                 )
                 .WithResponse(rsp =>
-                    rsp.WithBody(JsonSerializer.Serialize(new[] { importNotification }))
+                    rsp.WithBody(JsonSerializer.Serialize(new ImportPreNotificationsResponse([importNotification])))
                         .WithStatusCode(HttpStatusCode.OK)
                 )
         );

--- a/tests/Deriver.Tests/Consumers/ImportPreNotificationConsumerTests.cs
+++ b/tests/Deriver.Tests/Consumers/ImportPreNotificationConsumerTests.cs
@@ -26,6 +26,9 @@ public class ImportPreNotificationConsumerTests
         };
 
         var createdEvent = ImportPreNotificationFixtures.ImportPreNotificationCreatedFixture();
+        apiClient
+            .GetCustomsDeclarationsByChedId(createdEvent.ResourceId, Arg.Any<CancellationToken>())
+            .Returns(new CustomsDeclarationsResponse([]));
 
         var decisionResult = new DecisionResult();
         decisionResult.AddDecision("mrn", 1, "docref", "checkCode", DecisionCode.C03);
@@ -56,18 +59,20 @@ public class ImportPreNotificationConsumerTests
         customsDeclaration = customsDeclaration with { Finalisation = null };
         apiClient
             .GetCustomsDeclarationsByChedId(createdEvent.ResourceId, Arg.Any<CancellationToken>())
-            .Returns([customsDeclaration]);
+            .Returns(new CustomsDeclarationsResponse([customsDeclaration]));
 
         apiClient
             .GetImportPreNotificationsByMrn(customsDeclaration.MovementReferenceNumber, Arg.Any<CancellationToken>())
             .Returns(
-                [
-                    new ImportPreNotificationResponse(
-                        ImportPreNotificationFixtures.ImportPreNotificationFixture("test")!,
-                        DateTime.Now,
-                        DateTime.Now
-                    ),
-                ]
+                new ImportPreNotificationsResponse(
+                    [
+                        new ImportPreNotificationResponse(
+                            ImportPreNotificationFixtures.ImportPreNotificationFixture("test")!,
+                            DateTime.Now,
+                            DateTime.Now
+                        ),
+                    ]
+                )
             );
 
         var decisionResult = new DecisionResult();
@@ -108,11 +113,15 @@ public class ImportPreNotificationConsumerTests
 
         apiClient
             .GetCustomsDeclarationsByChedId(createdEvent.ResourceId, Arg.Any<CancellationToken>())
-            .Returns([customsDeclaration]);
+            .Returns(new CustomsDeclarationsResponse([customsDeclaration]));
 
         apiClient
             .GetImportPreNotificationsByMrn(customsDeclaration.MovementReferenceNumber, Arg.Any<CancellationToken>())
-            .Returns([new ImportPreNotificationResponse(notification, DateTime.Now, DateTime.Now)]);
+            .Returns(
+                new ImportPreNotificationsResponse(
+                    [new ImportPreNotificationResponse(notification, DateTime.Now, DateTime.Now)]
+                )
+            );
 
         var decisionResult = new DecisionResult();
         decisionResult.AddDecision("mrn", 1, "docref", "checkCode", DecisionCode.C03);
@@ -143,7 +152,7 @@ public class ImportPreNotificationConsumerTests
 
         apiClient
             .GetCustomsDeclarationsByChedId(createdEvent.ResourceId, Arg.Any<CancellationToken>())
-            .Returns([customsDeclaration]);
+            .Returns(new CustomsDeclarationsResponse([customsDeclaration]));
 
         // ACT
         await consumer.OnHandle(createdEvent, CancellationToken.None);

--- a/tests/Deriver.Tests/Consumers/MediatorConsumerTests.cs
+++ b/tests/Deriver.Tests/Consumers/MediatorConsumerTests.cs
@@ -64,7 +64,9 @@ public class MediatorConsumerTests
             .GetCustomsDeclaration(createdEvent.ResourceId, Arg.Any<CancellationToken>())
             .Returns(customsDeclaration);
 
-        apiClient.GetImportPreNotificationsByMrn(createdEvent.ResourceId, Arg.Any<CancellationToken>()).Returns([]);
+        apiClient
+            .GetImportPreNotificationsByMrn(createdEvent.ResourceId, Arg.Any<CancellationToken>())
+            .Returns(new ImportPreNotificationsResponse([]));
 
         var decisionResult = new DecisionResult();
         decisionResult.AddDecision("mrn", 1, "docref", "checkCode", DecisionCode.C03);
@@ -104,18 +106,20 @@ public class MediatorConsumerTests
         customsDeclaration = customsDeclaration with { Finalisation = null };
         apiClient
             .GetCustomsDeclarationsByChedId(createdEvent.ResourceId, Arg.Any<CancellationToken>())
-            .Returns([customsDeclaration]);
+            .Returns(new CustomsDeclarationsResponse([customsDeclaration]));
 
         apiClient
             .GetImportPreNotificationsByMrn(customsDeclaration.MovementReferenceNumber, Arg.Any<CancellationToken>())
             .Returns(
-                [
-                    new ImportPreNotificationResponse(
-                        ImportPreNotificationFixtures.ImportPreNotificationFixture("test")!,
-                        DateTime.Now,
-                        DateTime.Now
-                    ),
-                ]
+                new ImportPreNotificationsResponse(
+                    [
+                        new ImportPreNotificationResponse(
+                            ImportPreNotificationFixtures.ImportPreNotificationFixture("test")!,
+                            DateTime.Now,
+                            DateTime.Now
+                        ),
+                    ]
+                )
             );
 
         var decisionResult = new DecisionResult();


### PR DESCRIPTION
List returning endpoints now have an object with a nested list returned instead, as it's a little more flexible going forward should we need to add any additional properties.

Therefore, the deriver needs to be updated to reflect the new data API response structure.