### PR TITLE
CDMS-711: Persist the ExternalCorrelationId from the ClearanceRequest

### DIFF
--- a/src/Deriver/Decisions/ClearanceDecisionBuilder.cs
+++ b/src/Deriver/Decisions/ClearanceDecisionBuilder.cs
@@ -13,7 +13,7 @@ public static class ClearanceDecisionBuilder
     {
         var decisions = decisionResult.Decisions.Where(x => x.Mrn == mrn).ToList();
 
-        return new ClearanceDecision()
+        return new ClearanceDecision
         {
             DecisionNumber = customsDeclaration.ClearanceDecision is { DecisionNumber: not null }
                 ? customsDeclaration.ClearanceDecision.DecisionNumber + 1
@@ -22,7 +22,7 @@ public static class ClearanceDecisionBuilder
                 customsDeclaration.ClearanceRequest?.ExternalVersion
             ),
             Timestamp = DateTime.UtcNow,
-            ExternalCorrelationId = customsDeclaration.ClearanceDecision?.ExternalCorrelationId,
+            ExternalCorrelationId = customsDeclaration.ClearanceRequest?.ExternalCorrelationId,
             ExternalVersionNumber = customsDeclaration.ClearanceRequest?.ExternalVersion,
             Items = BuildItems(customsDeclaration.ClearanceRequest!, decisions).ToArray(),
         };

--- a/tests/Deriver.Tests/Decisions/ClearanceDecisionBuilderTests.BuildClearanceDecision_WithNoReasons.verified.txt
+++ b/tests/Deriver.Tests/Decisions/ClearanceDecisionBuilderTests.BuildClearanceDecision_WithNoReasons.verified.txt
@@ -1,4 +1,5 @@
 ﻿{
+  ExternalCorrelationId: correlationId,
   ExternalVersionNumber: 22,
   DecisionNumber: 1,
   SourceVersion: CR-VERSION-22,

--- a/tests/Deriver.Tests/Decisions/ClearanceDecisionBuilderTests.BuildClearanceDecision_WithReasons.verified.txt
+++ b/tests/Deriver.Tests/Decisions/ClearanceDecisionBuilderTests.BuildClearanceDecision_WithReasons.verified.txt
@@ -1,4 +1,5 @@
 ﻿{
+  ExternalCorrelationId: correlationId,
   ExternalVersionNumber: 22,
   DecisionNumber: 1,
   SourceVersion: CR-VERSION-22,


### PR DESCRIPTION
The ExternalCorrelationId was using the ClearanceDecision's own ExternalCorrelationId.