### PR TITLE
Allow consumers per host to be configurable

### DIFF
--- a/src/Deriver/Configuration/DataApiOptions.cs
+++ b/src/Deriver/Configuration/DataApiOptions.cs
@@ -4,37 +4,36 @@ using System.Net;
 using System.Net.Http.Headers;
 using System.Text;
 
-namespace Defra.TradeImportsDecisionDeriver.Deriver.Configuration
+namespace Defra.TradeImportsDecisionDeriver.Deriver.Configuration;
+
+[ExcludeFromCodeCoverage]
+public class DataApiOptions
 {
-    [ExcludeFromCodeCoverage]
-    public class DataApiOptions
+    public const string SectionName = "DataApi";
+
+    [Required]
+    public required string BaseAddress { get; init; }
+
+    public string? Username { get; init; }
+
+    public string? Password { get; init; }
+
+    public string? BasicAuthCredential =>
+        Username != null && Password != null
+            ? Convert.ToBase64String(Encoding.UTF8.GetBytes($"{Username}:{Password}"))
+            : null;
+
+    public void Configure(HttpClient httpClient)
     {
-        public const string SectionName = "DataApi";
+        httpClient.BaseAddress = new Uri(BaseAddress);
 
-        [Required]
-        public required string BaseAddress { get; init; }
+        if (BasicAuthCredential != null)
+            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
+                "Basic",
+                BasicAuthCredential
+            );
 
-        public string? Username { get; init; }
-
-        public string? Password { get; init; }
-
-        public string? BasicAuthCredential =>
-            Username != null && Password != null
-                ? Convert.ToBase64String(Encoding.UTF8.GetBytes($"{Username}:{Password}"))
-                : null;
-
-        public void Configure(HttpClient httpClient)
-        {
-            httpClient.BaseAddress = new Uri(BaseAddress);
-
-            if (BasicAuthCredential != null)
-                httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
-                    "Basic",
-                    BasicAuthCredential
-                );
-
-            if (httpClient.BaseAddress.Scheme.Equals("https", StringComparison.OrdinalIgnoreCase))
-                httpClient.DefaultRequestVersion = HttpVersion.Version20;
-        }
+        if (httpClient.BaseAddress.Scheme.Equals("https", StringComparison.OrdinalIgnoreCase))
+            httpClient.DefaultRequestVersion = HttpVersion.Version20;
     }
 }

--- a/src/Deriver/Configuration/DataApiOptions.cs
+++ b/src/Deriver/Configuration/DataApiOptions.cs
@@ -18,7 +18,7 @@ public class DataApiOptions
 
     public string? Password { get; init; }
 
-    public string? BasicAuthCredential =>
+    private string? BasicAuthCredential =>
         Username != null && Password != null
             ? Convert.ToBase64String(Encoding.UTF8.GetBytes($"{Username}:{Password}"))
             : null;

--- a/src/Deriver/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Deriver/Extensions/ServiceCollectionExtensions.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics.CodeAnalysis;
-using System.Text.Json;
 using Defra.TradeImportsDataApi.Api.Client;
 using Defra.TradeImportsDecisionDeriver.Deriver.Configuration;
 using Defra.TradeImportsDecisionDeriver.Deriver.Consumers;
@@ -17,7 +16,6 @@ using SlimMessageBus.Host;
 using SlimMessageBus.Host.AmazonSQS;
 using SlimMessageBus.Host.Interceptor;
 using SlimMessageBus.Host.Serialization;
-using SlimMessageBus.Host.Serialization.SystemTextJson;
 
 namespace Defra.TradeImportsDecisionDeriver.Deriver.Extensions;
 

--- a/src/Deriver/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Deriver/Extensions/ServiceCollectionExtensions.cs
@@ -54,6 +54,9 @@ public static class ServiceCollectionExtensions
         services.AddSlimMessageBus(mbb =>
         {
             var queueName = configuration.GetValue<string>("DATA_EVENTS_QUEUE_NAME");
+            var consumersPerHost = configuration.GetValue<int>("CONSUMERS_PER_HOST");
+            if (consumersPerHost <= 0)
+                consumersPerHost = 20;
 
             mbb.RegisterSerializer<ToStringSerializer>(s =>
             {
@@ -73,7 +76,7 @@ public static class ServiceCollectionExtensions
                 );
             });
 
-            mbb.Consume<string>(x => x.WithConsumer<ConsumerMediator>().Queue(queueName).Instances(20));
+            mbb.Consume<string>(x => x.WithConsumer<ConsumerMediator>().Queue(queueName).Instances(consumersPerHost));
         });
 
         return services;


### PR DESCRIPTION
As per PR title.

Not pulling in additional configuration at this time, just what's needed. 

SMB is not flexible in terms of accessing the service provider during bootstrapping.