### PR TITLE
CDMS-730: Amend to use latest domain classes

### DIFF
--- a/src/Deriver/Consumers/ClearanceRequestConsumer.cs
+++ b/src/Deriver/Consumers/ClearanceRequestConsumer.cs
@@ -75,21 +75,21 @@ public class ClearanceRequestConsumer(
     }
 
     private async Task PersistDecision(
-        CustomsDeclarationResponse clearanceRequest,
+        CustomsDeclarationResponse existingCustomsDeclaration,
         DecisionResult decisionResult,
         CancellationToken cancellationToken
     )
     {
         var customsDeclaration = new CustomsDeclaration()
         {
-            ClearanceDecision = clearanceRequest.ClearanceDecision,
-            Finalisation = clearanceRequest.Finalisation,
-            ClearanceRequest = clearanceRequest.ClearanceRequest,
-            InboundError = clearanceRequest.InboundError,
+            ClearanceDecision = existingCustomsDeclaration.ClearanceDecision,
+            Finalisation = existingCustomsDeclaration.Finalisation,
+            ClearanceRequest = existingCustomsDeclaration.ClearanceRequest,
+            ExternalErrors = existingCustomsDeclaration.ExternalErrors,
         };
 
         var newDecision = decisionResult.BuildClearanceDecision(
-            clearanceRequest.MovementReferenceNumber,
+            existingCustomsDeclaration.MovementReferenceNumber,
             customsDeclaration
         );
 
@@ -98,9 +98,9 @@ public class ClearanceRequestConsumer(
             customsDeclaration.ClearanceDecision = newDecision;
 
             await apiClient.PutCustomsDeclaration(
-                clearanceRequest.MovementReferenceNumber,
+                existingCustomsDeclaration.MovementReferenceNumber,
                 customsDeclaration,
-                clearanceRequest.ETag,
+                existingCustomsDeclaration.ETag,
                 cancellationToken
             );
         }

--- a/src/Deriver/Consumers/ImportPreNotificationConsumer.cs
+++ b/src/Deriver/Consumers/ImportPreNotificationConsumer.cs
@@ -73,14 +73,14 @@ public class ImportPreNotificationConsumer(
     {
         foreach (var mrn in clearanceRequests.Select(x => x.MovementReferenceNumber))
         {
-            var clearanceRequest = await apiClient.GetCustomsDeclaration(mrn, cancellationToken);
+            var existingCustomsDeclaration = await apiClient.GetCustomsDeclaration(mrn, cancellationToken);
 
             var customsDeclaration = new CustomsDeclaration()
             {
-                ClearanceDecision = clearanceRequest?.ClearanceDecision,
-                Finalisation = clearanceRequest?.Finalisation,
-                ClearanceRequest = clearanceRequest?.ClearanceRequest,
-                InboundError = clearanceRequest?.InboundError,
+                ClearanceDecision = existingCustomsDeclaration?.ClearanceDecision,
+                Finalisation = existingCustomsDeclaration?.Finalisation,
+                ClearanceRequest = existingCustomsDeclaration?.ClearanceRequest,
+                ExternalErrors = existingCustomsDeclaration?.ExternalErrors,
             };
 
             var newDecision = decisionResult.BuildClearanceDecision(mrn, customsDeclaration);
@@ -91,7 +91,7 @@ public class ImportPreNotificationConsumer(
                 await apiClient.PutCustomsDeclaration(
                     mrn,
                     customsDeclaration,
-                    clearanceRequest?.ETag,
+                    existingCustomsDeclaration?.ETag,
                     cancellationToken
                 );
             }

--- a/src/Deriver/Decisions/ClearanceDecisionBuilder.cs
+++ b/src/Deriver/Decisions/ClearanceDecisionBuilder.cs
@@ -21,8 +21,9 @@ public static class ClearanceDecisionBuilder
             SourceVersion = decisionResult.BuildDecisionSourceVersion(
                 customsDeclaration.ClearanceRequest?.ExternalVersion
             ),
-            Timestamp = DateTime.UtcNow,
-            ExternalCorrelationId = customsDeclaration.ClearanceRequest?.ExternalCorrelationId,
+            Created = DateTime.UtcNow,
+            // logic to generate the correlation Id will need to be applied here when HMRC have confirmed the proposed approach
+            CorrelationId = customsDeclaration.ClearanceRequest?.ExternalCorrelationId,
             ExternalVersionNumber = customsDeclaration.ClearanceRequest?.ExternalVersion,
             Items = BuildItems(customsDeclaration.ClearanceRequest!, decisions).ToArray(),
         };

--- a/src/Deriver/Deriver.csproj
+++ b/src/Deriver/Deriver.csproj
@@ -15,7 +15,7 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Defra.TradeImportsDataApi.Api.Client" Version="0.25.0-pr-113.653" />
+    <PackageReference Include="Defra.TradeImportsDataApi.Api.Client" Version="0.26.0-pr-133.731" />
     <PackageReference Include="Elastic.CommonSchema.Serilog" Version="8.12.3" />
     <PackageReference Include="Elastic.Serilog.Enrichers.Web" Version="8.12.3" />
     <PackageReference Include="Microsoft.AspNetCore.HeaderPropagation" Version="9.0.5" />

--- a/tests/Deriver.Tests/Decisions/ClearanceDecisionBuilderTests.BuildClearanceDecision_WithNoReasons.verified.txt
+++ b/tests/Deriver.Tests/Decisions/ClearanceDecisionBuilderTests.BuildClearanceDecision_WithNoReasons.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  ExternalCorrelationId: correlationId,
+  CorrelationId: correlationId,
   ExternalVersionNumber: 22,
   DecisionNumber: 1,
   SourceVersion: CR-VERSION-22,

--- a/tests/Deriver.Tests/Decisions/ClearanceDecisionBuilderTests.BuildClearanceDecision_WithNoReasons_AndPreviousDecision.verified.txt
+++ b/tests/Deriver.Tests/Decisions/ClearanceDecisionBuilderTests.BuildClearanceDecision_WithNoReasons_AndPreviousDecision.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  ExternalCorrelationId: correlationId,
+  CorrelationId: correlationId,
   ExternalVersionNumber: 22,
   DecisionNumber: 5,
   SourceVersion: CR-VERSION-22,

--- a/tests/Deriver.Tests/Decisions/ClearanceDecisionBuilderTests.BuildClearanceDecision_WithNotReasons.verified.txt
+++ b/tests/Deriver.Tests/Decisions/ClearanceDecisionBuilderTests.BuildClearanceDecision_WithNotReasons.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  externalCorrelationId: cf16956d-9c68-4502-b78b-0b3e0d9ca72a,
+  correlationId: cf16956d-9c68-4502-b78b-0b3e0d9ca72a,
   timestamp: 2025-04-16T07:50:28.7871474Z,
   externalVersionNumber: 90,
   decisionNumber: 1,

--- a/tests/Deriver.Tests/Decisions/ClearanceDecisionBuilderTests.BuildClearanceDecision_WithReasons.verified.txt
+++ b/tests/Deriver.Tests/Decisions/ClearanceDecisionBuilderTests.BuildClearanceDecision_WithReasons.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  ExternalCorrelationId: correlationId,
+  CorrelationId: correlationId,
   ExternalVersionNumber: 22,
   DecisionNumber: 1,
   SourceVersion: CR-VERSION-22,

--- a/tests/Deriver.Tests/Decisions/ClearanceDecisionBuilderTests.cs
+++ b/tests/Deriver.Tests/Decisions/ClearanceDecisionBuilderTests.cs
@@ -13,7 +13,7 @@ public class ClearanceDecisionBuilderTests
     public ClearanceDecisionBuilderTests()
     {
         _settings = new VerifySettings();
-        _settings.IgnoreMember<ClearanceDecision>(x => x.Timestamp);
+        _settings.IgnoreMember<ClearanceDecision>(x => x.Created);
         _settings.DontScrubDateTimes();
         _settings.DontScrubGuids();
     }
@@ -107,7 +107,7 @@ public class ClearanceDecisionBuilderTests
     {
         var customsDeclaration = CustomsDeclarationResponseFixtures.CustomsDeclarationResponseFixture();
         customsDeclaration.ClearanceRequest!.ExternalCorrelationId = "correlationId";
-        customsDeclaration.ClearanceDecision!.ExternalCorrelationId = "correlationId";
+        customsDeclaration.ClearanceDecision!.CorrelationId = "correlationId";
         customsDeclaration.ClearanceRequest!.ExternalVersion = 22;
         customsDeclaration.ClearanceDecision!.DecisionNumber = 4;
         var decisionResult = new DecisionResult();


### PR DESCRIPTION
The `Defra.TradeImportsDataApi.Domain` nuget package has changed to ensure field names are consistent across classes.
The decision-deriver has been updated in this PR to use the latest domain classes.
Note: the correlation identifier on the clearance decision will need to be assigned when we have received confirmation of the proposed logic from HMRC.   