### PR TITLE
Return Value for ToString so any use of a check code in logs is correct

### DIFF
--- a/src/Deriver/Decisions/Finders/CheckCode.cs
+++ b/src/Deriver/Decisions/Finders/CheckCode.cs
@@ -10,7 +10,7 @@ public class CheckCode
 
     public string? GetImportNotificationType()
     {
-        //This is the mapping from https://eaflood.atlassian.net/wiki/spaces/ALVS/pages/5400920093/DocumentCode+CheckCode+Mapping
+        // This is the mapping from https://eaflood.atlassian.net/wiki/spaces/ALVS/pages/5400920093/DocumentCode+CheckCode+Mapping
         return Value switch
         {
             "H221" => ImportNotificationType.Cveda,
@@ -25,4 +25,6 @@ public class CheckCode
     {
         return Value == IuuCheckCode;
     }
+
+    public override string ToString() => Value;
 }


### PR DESCRIPTION
As per PR title.

We have observed logs where the type "CheckCode" is logged instead of the internal value, therefore provide an implementation for `ToString`.