### PR TITLE
CDMS-554: enable message consumption to auto-start

### DIFF
--- a/src/Deriver/appsettings.cdp.prod.json
+++ b/src/Deriver/appsettings.cdp.prod.json
@@ -1,5 +1,5 @@
 {
-  "AUTO_START_CONSUMERS": false,
+  "AUTO_START_CONSUMERS": true,
   "DataApi": {
     "BaseAddress": "https://trade-imports-data-api.prod.cdp-int.defra.cloud"
   }


### PR DESCRIPTION
To enable the decision deriver to read messages from SQS.