### PR TITLE
Improve naming of comparers and add log for when decision is made but it does not need to persist

### DIFF
--- a/src/Deriver/Consumers/ClearanceRequestConsumer.cs
+++ b/src/Deriver/Consumers/ClearanceRequestConsumer.cs
@@ -80,7 +80,7 @@ public class ClearanceRequestConsumer(
             correlationIdGenerator
         );
 
-        if (!ClearanceDecisionComparer.Default.Equals(newDecision, customsDeclaration.ClearanceDecision))
+        if (!DecisionExistsComparer.Default.Equals(newDecision, customsDeclaration.ClearanceDecision))
         {
             customsDeclaration.ClearanceDecision = newDecision;
 
@@ -89,6 +89,13 @@ public class ClearanceRequestConsumer(
                 customsDeclaration,
                 existingCustomsDeclaration.ETag,
                 cancellationToken
+            );
+        }
+        else
+        {
+            logger.LogInformation(
+                "Decision already exists, not persisting (source version {SourceVersion})",
+                customsDeclaration.ClearanceDecision.SourceVersion
             );
         }
     }

--- a/src/Deriver/Consumers/ImportPreNotificationConsumer.cs
+++ b/src/Deriver/Consumers/ImportPreNotificationConsumer.cs
@@ -68,7 +68,7 @@ public class ImportPreNotificationConsumer(
 
             var newDecision = decisionResult.BuildClearanceDecision(mrn, customsDeclaration, correlationIdGenerator);
 
-            if (!ClearanceDecisionComparer.Default.Equals(newDecision, customsDeclaration.ClearanceDecision))
+            if (!DecisionExistsComparer.Default.Equals(newDecision, customsDeclaration.ClearanceDecision))
             {
                 customsDeclaration.ClearanceDecision = newDecision;
 
@@ -77,6 +77,13 @@ public class ImportPreNotificationConsumer(
                     customsDeclaration,
                     existingCustomsDeclaration?.ETag,
                     cancellationToken
+                );
+            }
+            else
+            {
+                logger.LogInformation(
+                    "Decision already exists, not persisting (source version {SourceVersion})",
+                    customsDeclaration.ClearanceDecision.SourceVersion
                 );
             }
         }

--- a/src/Deriver/Decisions/ClearanceDecisionBuilder.cs
+++ b/src/Deriver/Decisions/ClearanceDecisionBuilder.cs
@@ -24,7 +24,6 @@ public static class ClearanceDecisionBuilder
                 customsDeclaration.ClearanceRequest?.ExternalVersion
             ),
             Created = DateTime.UtcNow,
-            // logic to generate the correlation Id will need to be applied here when HMRC have confirmed the proposed approach
             CorrelationId = correlationIdGenerator.Generate(),
             ExternalVersionNumber = customsDeclaration.ClearanceRequest?.ExternalVersion,
             Items = BuildItems(customsDeclaration.ClearanceRequest!, decisions).ToArray(),

--- a/src/Deriver/Decisions/Comparers/DecisionExistsComparer.cs
+++ b/src/Deriver/Decisions/Comparers/DecisionExistsComparer.cs
@@ -2,21 +2,28 @@ using Defra.TradeImportsDataApi.Domain.CustomsDeclaration;
 
 namespace Defra.TradeImportsDecisionDeriver.Deriver.Decisions.Comparers;
 
-public class ClearanceDecisionComparer : IEqualityComparer<ClearanceDecision>
+/// <summary>
+/// Only use when comparing decisions to determine if a new
+/// decision should be persisted.
+/// </summary>
+public class DecisionExistsComparer : IEqualityComparer<ClearanceDecision>
 {
-    public static readonly ClearanceDecisionComparer Default = new();
+    public static readonly DecisionExistsComparer Default = new();
 
     public bool Equals(ClearanceDecision? x, ClearanceDecision? y)
     {
         if (ReferenceEquals(x, y))
             return true;
+
         if (x is null)
             return false;
+
         if (y is null)
             return false;
+
         return x.SourceVersion == y.SourceVersion
-            || x.Items.OrderBy(x => x.ItemNumber)
-                .SequenceEqual(y.Items.OrderBy(x => x.ItemNumber), ClearanceDecisionItemComparer.Default);
+            || x.Items.OrderBy(item => item.ItemNumber)
+                .SequenceEqual(y.Items.OrderBy(item => item.ItemNumber), DecisionItemExistsComparer.Default);
     }
 
     public int GetHashCode(ClearanceDecision obj)

--- a/src/Deriver/Decisions/Comparers/DecisionItemCheckExistsComparer.cs
+++ b/src/Deriver/Decisions/Comparers/DecisionItemCheckExistsComparer.cs
@@ -2,18 +2,25 @@ using Defra.TradeImportsDataApi.Domain.CustomsDeclaration;
 
 namespace Defra.TradeImportsDecisionDeriver.Deriver.Decisions.Comparers;
 
-public class ClearanceDecisionCheckComparer : IEqualityComparer<ClearanceDecisionCheck>
+/// <summary>
+/// Only use when comparing decisions to determine if a new
+/// decision should be persisted.
+/// </summary>
+public class DecisionItemCheckExistsComparer : IEqualityComparer<ClearanceDecisionCheck>
 {
-    public static readonly ClearanceDecisionCheckComparer Default = new();
+    public static readonly DecisionItemCheckExistsComparer Default = new();
 
     public bool Equals(ClearanceDecisionCheck? x, ClearanceDecisionCheck? y)
     {
         if (ReferenceEquals(x, y))
             return true;
+
         if (x is null)
             return false;
+
         if (y is null)
             return false;
+
         return x.CheckCode == y.CheckCode && x.DecisionCode == y.DecisionCode;
     }
 

--- a/src/Deriver/Decisions/Comparers/DecisionItemExistsComparer.cs
+++ b/src/Deriver/Decisions/Comparers/DecisionItemExistsComparer.cs
@@ -2,21 +2,28 @@ using Defra.TradeImportsDataApi.Domain.CustomsDeclaration;
 
 namespace Defra.TradeImportsDecisionDeriver.Deriver.Decisions.Comparers;
 
-public class ClearanceDecisionItemComparer : IEqualityComparer<ClearanceDecisionItem>
+/// <summary>
+/// Only use when comparing decisions to determine if a new
+/// decision should be persisted.
+/// </summary>
+public class DecisionItemExistsComparer : IEqualityComparer<ClearanceDecisionItem>
 {
-    public static readonly ClearanceDecisionItemComparer Default = new();
+    public static readonly DecisionItemExistsComparer Default = new();
 
     public bool Equals(ClearanceDecisionItem? x, ClearanceDecisionItem? y)
     {
         if (ReferenceEquals(x, y))
             return true;
+
         if (x is null)
             return false;
+
         if (y is null)
             return false;
+
         return x.ItemNumber == y.ItemNumber
-            && x.Checks.OrderBy(x => x.CheckCode)
-                .SequenceEqual(y.Checks.OrderBy(x => x.CheckCode), ClearanceDecisionCheckComparer.Default);
+            && x.Checks.OrderBy(check => check.CheckCode)
+                .SequenceEqual(y.Checks.OrderBy(check => check.CheckCode), DecisionItemCheckExistsComparer.Default);
     }
 
     public int GetHashCode(ClearanceDecisionItem obj)

--- a/tests/Deriver.Tests/Comparers/DecisionExistsComparerTests.cs
+++ b/tests/Deriver.Tests/Comparers/DecisionExistsComparerTests.cs
@@ -3,7 +3,7 @@ using Defra.TradeImportsDecisionDeriver.Deriver.Decisions.Comparers;
 
 namespace Defra.TradeImportsDecisionDeriver.Deriver.Tests.Comparers;
 
-public class ClearanceDecisionComparerTests
+public class DecisionExistsComparerTests
 {
     [Fact]
     public void HashCodeTest()
@@ -20,7 +20,7 @@ public class ClearanceDecisionComparerTests
                 },
             ],
         };
-        var sut = new ClearanceDecisionComparer();
+        var sut = new DecisionExistsComparer();
 
         Action act = () => sut.GetHashCode(decision);
 
@@ -42,7 +42,7 @@ public class ClearanceDecisionComparerTests
                 },
             ],
         };
-        var sut = new ClearanceDecisionComparer();
+        var sut = new DecisionExistsComparer();
 
         var result = sut.Equals(decision, decision);
 
@@ -64,7 +64,7 @@ public class ClearanceDecisionComparerTests
                 },
             ],
         };
-        var sut = new ClearanceDecisionComparer();
+        var sut = new DecisionExistsComparer();
 
         var result = sut.Equals(null, decision);
 
@@ -86,7 +86,7 @@ public class ClearanceDecisionComparerTests
                 },
             ],
         };
-        var sut = new ClearanceDecisionComparer();
+        var sut = new DecisionExistsComparer();
 
         var result = sut.Equals(decision, null);
 
@@ -121,7 +121,7 @@ public class ClearanceDecisionComparerTests
                 },
             ],
         };
-        var sut = new ClearanceDecisionComparer();
+        var sut = new DecisionExistsComparer();
 
         var result = sut.Equals(decision1, decision2);
 
@@ -166,7 +166,7 @@ public class ClearanceDecisionComparerTests
                 },
             ],
         };
-        var sut = new ClearanceDecisionComparer();
+        var sut = new DecisionExistsComparer();
 
         var result = sut.Equals(decision1, decision2);
 

--- a/tests/Deriver.Tests/Comparers/DecisionItemCheckExistsComparerTests.cs
+++ b/tests/Deriver.Tests/Comparers/DecisionItemCheckExistsComparerTests.cs
@@ -3,13 +3,13 @@ using Defra.TradeImportsDecisionDeriver.Deriver.Decisions.Comparers;
 
 namespace Defra.TradeImportsDecisionDeriver.Deriver.Tests.Comparers;
 
-public class ClearanceDecisionCheckComparerTests
+public class DecisionItemCheckExistsComparerTests
 {
     [Fact]
     public void HashCodeTest()
     {
         var check = new ClearanceDecisionCheck { CheckCode = "H201", DecisionCode = "C03" };
-        var sut = new ClearanceDecisionCheckComparer();
+        var sut = new DecisionItemCheckExistsComparer();
 
         Action act = () => sut.GetHashCode(check);
 
@@ -20,7 +20,7 @@ public class ClearanceDecisionCheckComparerTests
     public void ReferenceEqualsTest()
     {
         var check = new ClearanceDecisionCheck { CheckCode = "H201", DecisionCode = "C03" };
-        var sut = new ClearanceDecisionCheckComparer();
+        var sut = new DecisionItemCheckExistsComparer();
 
         var result = sut.Equals(check, check);
 
@@ -31,7 +31,7 @@ public class ClearanceDecisionCheckComparerTests
     public void FirstItemIsNull()
     {
         var check = new ClearanceDecisionCheck { CheckCode = "H201", DecisionCode = "C03" };
-        var sut = new ClearanceDecisionCheckComparer();
+        var sut = new DecisionItemCheckExistsComparer();
 
         var result = sut.Equals(check, null);
 
@@ -42,7 +42,7 @@ public class ClearanceDecisionCheckComparerTests
     public void SecondItemIsNull()
     {
         var check = new ClearanceDecisionCheck { CheckCode = "H201", DecisionCode = "C03" };
-        var sut = new ClearanceDecisionCheckComparer();
+        var sut = new DecisionItemCheckExistsComparer();
 
         var result = sut.Equals(null, check);
 
@@ -54,7 +54,7 @@ public class ClearanceDecisionCheckComparerTests
     {
         var check1 = new ClearanceDecisionCheck { CheckCode = "H201", DecisionCode = "C03" };
         var check2 = new ClearanceDecisionCheck { CheckCode = "H201", DecisionCode = "C03" };
-        var sut = new ClearanceDecisionCheckComparer();
+        var sut = new DecisionItemCheckExistsComparer();
 
         var result = sut.Equals(check1, check2);
 
@@ -66,7 +66,7 @@ public class ClearanceDecisionCheckComparerTests
     {
         var check1 = new ClearanceDecisionCheck { CheckCode = "H201", DecisionCode = "C03" };
         var check2 = new ClearanceDecisionCheck { CheckCode = "H202", DecisionCode = "C03" };
-        var sut = new ClearanceDecisionCheckComparer();
+        var sut = new DecisionItemCheckExistsComparer();
 
         var result = sut.Equals(check1, check2);
 
@@ -78,7 +78,7 @@ public class ClearanceDecisionCheckComparerTests
     {
         var check1 = new ClearanceDecisionCheck { CheckCode = "H201", DecisionCode = "C03" };
         var check2 = new ClearanceDecisionCheck { CheckCode = "H201", DecisionCode = "C04" };
-        var sut = new ClearanceDecisionCheckComparer();
+        var sut = new DecisionItemCheckExistsComparer();
 
         var result = sut.Equals(check1, check2);
 

--- a/tests/Deriver.Tests/Comparers/DecisionItemExistsComparerTests.cs
+++ b/tests/Deriver.Tests/Comparers/DecisionItemExistsComparerTests.cs
@@ -3,7 +3,7 @@ using Defra.TradeImportsDecisionDeriver.Deriver.Decisions.Comparers;
 
 namespace Defra.TradeImportsDecisionDeriver.Deriver.Tests.Comparers;
 
-public class ClearanceDecisionItemComparerTests
+public class DecisionItemExistsComparerTests
 {
     [Fact]
     public void HashCodeTest()
@@ -13,7 +13,7 @@ public class ClearanceDecisionItemComparerTests
             ItemNumber = 1,
             Checks = [new ClearanceDecisionCheck { CheckCode = "H201", DecisionCode = "C03" }],
         };
-        var sut = new ClearanceDecisionItemComparer();
+        var sut = new DecisionItemExistsComparer();
 
         Action act = () => sut.GetHashCode(item);
 
@@ -28,7 +28,7 @@ public class ClearanceDecisionItemComparerTests
             ItemNumber = 1,
             Checks = [new ClearanceDecisionCheck { CheckCode = "H201", DecisionCode = "C03" }],
         };
-        var sut = new ClearanceDecisionItemComparer();
+        var sut = new DecisionItemExistsComparer();
 
         var result = sut.Equals(item, item);
 
@@ -43,7 +43,7 @@ public class ClearanceDecisionItemComparerTests
             ItemNumber = 1,
             Checks = [new ClearanceDecisionCheck { CheckCode = "H201", DecisionCode = "C03" }],
         };
-        var sut = new ClearanceDecisionItemComparer();
+        var sut = new DecisionItemExistsComparer();
 
         var result = sut.Equals(null, item);
 
@@ -58,7 +58,7 @@ public class ClearanceDecisionItemComparerTests
             ItemNumber = 1,
             Checks = [new ClearanceDecisionCheck { CheckCode = "H201", DecisionCode = "C03" }],
         };
-        var sut = new ClearanceDecisionItemComparer();
+        var sut = new DecisionItemExistsComparer();
 
         var result = sut.Equals(item, null);
 
@@ -78,7 +78,7 @@ public class ClearanceDecisionItemComparerTests
             ItemNumber = 1,
             Checks = [new ClearanceDecisionCheck { CheckCode = "H201", DecisionCode = "C03" }],
         };
-        var sut = new ClearanceDecisionItemComparer();
+        var sut = new DecisionItemExistsComparer();
 
         var result = sut.Equals(item1, item2);
 
@@ -98,7 +98,7 @@ public class ClearanceDecisionItemComparerTests
             ItemNumber = 2,
             Checks = [new ClearanceDecisionCheck { CheckCode = "H201", DecisionCode = "C03" }],
         };
-        var sut = new ClearanceDecisionItemComparer();
+        var sut = new DecisionItemExistsComparer();
 
         var result = sut.Equals(item1, item2);
 
@@ -118,7 +118,7 @@ public class ClearanceDecisionItemComparerTests
             ItemNumber = 1,
             Checks = [new ClearanceDecisionCheck { CheckCode = "H202", DecisionCode = "C03" }],
         };
-        var sut = new ClearanceDecisionItemComparer();
+        var sut = new DecisionItemExistsComparer();
 
         var result = sut.Equals(item1, item2);
 
@@ -146,7 +146,7 @@ public class ClearanceDecisionItemComparerTests
                 new ClearanceDecisionCheck { CheckCode = "H201", DecisionCode = "C04" },
             ],
         };
-        var sut = new ClearanceDecisionItemComparer();
+        var sut = new DecisionItemExistsComparer();
 
         var result = sut.Equals(item1, item2);
 


### PR DESCRIPTION
The comparers being used to determine if a decision could be persisted had general names yet they have a specific purpose. Therefore, the intention is to rename as such and also add a comment to say don't use them if you're not determining decision existence.

Also added log for when they are used and the deriver concludes it does not need to save the decision ie. it's not changed. This would be a useful log to observe during message replay when events are retried due to concurrency issues on the first attempt.

Also removed log related to correlation IDs that is no longer needed.