### PR TITLE
Bug CDMS-875

### DIFF
--- a/src/Deriver/Decisions/DecisionCode.cs
+++ b/src/Deriver/Decisions/DecisionCode.cs
@@ -23,6 +23,7 @@ public enum DecisionCode
 
 public enum DecisionInternalFurtherDetail
 {
+    E87, // No Documents
     E88, // Cancelled or Replaced or Deleted
     E89, // Item with document references where none are valid format
     E90, // No Decision Finder found

--- a/src/Deriver/Decisions/DecisionService.cs
+++ b/src/Deriver/Decisions/DecisionService.cs
@@ -150,16 +150,30 @@ public class DecisionService(
 
         if (decisions.Count == 0)
         {
-            foreach (var document in item.Documents!)
+            if (item.Documents == null)
             {
                 decisionsResult.AddDecision(
                     mrn,
                     itemNumber,
-                    document.DocumentReference!.Value,
+                    string.Empty,
                     null,
                     DecisionCode.X00,
-                    internalDecisionCode: DecisionInternalFurtherDetail.E89
+                    internalDecisionCode: DecisionInternalFurtherDetail.E87
                 );
+            }
+            else
+            {
+                foreach (var document in item.Documents)
+                {
+                    decisionsResult.AddDecision(
+                        mrn,
+                        itemNumber,
+                        document.DocumentReference!.Value,
+                        null,
+                        DecisionCode.X00,
+                        internalDecisionCode: DecisionInternalFurtherDetail.E89
+                    );
+                }
             }
         }
     }

--- a/tests/Deriver.Tests/Decisions/DecisionServiceTests.cs
+++ b/tests/Deriver.Tests/Decisions/DecisionServiceTests.cs
@@ -53,6 +53,56 @@ public class DecisionServiceTests
         decisionResult.Decisions[0].DecisionCode.Should().Be(expectedDecisionCode);
     }
 
+    [Fact]
+    public async Task When_processing_clearance_request_with_null_documents_then_no_match_should_be_generated()
+    {
+        var matchingResult = new MatchingResult();
+
+        var matchingService = Substitute.For<IMatchingService>();
+        matchingService
+            .Process(Arg.Any<MatchingContext>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(matchingResult));
+
+        var decisionContext = new DecisionContext(
+            [],
+            [
+                new ClearanceRequestWrapper(
+                    "clearancerequest-1",
+                    new ClearanceRequest
+                    {
+                        Commodities =
+                        [
+                            new Commodity
+                            {
+                                ItemNumber = 1,
+                                Documents = null,
+                                Checks = [new CommodityCheck { CheckCode = "H221" }],
+                            },
+                        ],
+                    }
+                ),
+            ]
+        );
+
+        var sut = new DecisionService(
+            NullLogger<DecisionService>.Instance,
+            matchingService,
+            [
+                new ChedADecisionFinder(),
+                new ChedDDecisionFinder(),
+                new ChedPDecisionFinder(),
+                new ChedPPDecisionFinder(),
+                new IuuDecisionFinder(),
+            ]
+        );
+
+        var decisionResult = await sut.Process(decisionContext, CancellationToken.None);
+
+        decisionResult.Decisions.Should().HaveCount(1);
+        decisionResult.Decisions[0].DecisionCode.Should().Be(DecisionCode.X00);
+        decisionResult.Decisions[0].InternalDecisionCode.Should().Be(DecisionInternalFurtherDetail.E87);
+    }
+
     private static DecisionContext CreateDecisionContext(
         string? importNotificationType,
         string[]? checkCodes,


### PR DESCRIPTION
It is possible for Documents on the Item to be null, which wasn't being handled, and throwing a null reference exception.

This PR Adds checks for Documents being null, and returns an X00 with a new dedicated internal code.