### PR TITLE
Handle NotAcceptable ConsignmentDecision

### DIFF
--- a/src/Deriver/Decisions/DecisionImportPreNotification.cs
+++ b/src/Deriver/Decisions/DecisionImportPreNotification.cs
@@ -36,4 +36,11 @@ public class DecisionImportPreNotification
 
     [JsonPropertyName("commodities")]
     public DecisionCommodityComplement[] Commodities { get; set; } = [];
+
+    public bool HasAcceptableConsignmentDecision()
+    {
+        return ConsignmentDecision is not null
+            && ConsignmentDecision
+                != Defra.TradeImportsDecisionDeriver.Deriver.Decisions.ConsignmentDecision.NonAcceptable;
+    }
 }

--- a/src/Deriver/Decisions/Finders/ChedADecisionFinder.cs
+++ b/src/Deriver/Decisions/Finders/ChedADecisionFinder.cs
@@ -17,7 +17,7 @@ public class ChedADecisionFinder : DecisionFinder
             return new DecisionFinderResult(code!.Value, checkCode);
         }
 
-        if (notification.ConsignmentDecision is not null)
+        if (notification.HasAcceptableConsignmentDecision())
         {
             return notification.ConsignmentDecision switch
             {

--- a/src/Deriver/Decisions/Finders/ChedDDecisionFinder.cs
+++ b/src/Deriver/Decisions/Finders/ChedDDecisionFinder.cs
@@ -19,7 +19,7 @@ public class ChedDDecisionFinder : DecisionFinder
             return new DecisionFinderResult(code!.Value, checkCode);
         }
 
-        if (notification.ConsignmentDecision is not null)
+        if (notification.HasAcceptableConsignmentDecision())
         {
             return notification.ConsignmentDecision switch
             {

--- a/src/Deriver/Decisions/Finders/ChedPDecisionFinder.cs
+++ b/src/Deriver/Decisions/Finders/ChedPDecisionFinder.cs
@@ -21,7 +21,7 @@ public class ChedPDecisionFinder : DecisionFinder
             return new DecisionFinderResult(code!.Value, checkCode);
         }
 
-        if (notification.ConsignmentDecision is not null)
+        if (notification.HasAcceptableConsignmentDecision())
         {
             return notification.ConsignmentDecision switch
             {

--- a/tests/Deriver.Tests/Decisions/Finders/ChedADecisionFinderTests.cs
+++ b/tests/Deriver.Tests/Decisions/Finders/ChedADecisionFinderTests.cs
@@ -47,13 +47,7 @@ public class ChedADecisionFinderTests
     [InlineData(ConsignmentDecision.AcceptableForInternalMarket, null, new[] { "Other" }, DecisionCode.C03)]
     [InlineData(ConsignmentDecision.AcceptableForTemporaryImport, null, new[] { "Other" }, DecisionCode.C05)]
     [InlineData(ConsignmentDecision.HorseReEntry, null, new[] { "Other" }, DecisionCode.C06)]
-    [InlineData(
-        ConsignmentDecision.NonAcceptable,
-        null,
-        new[] { "Other" },
-        DecisionCode.X00,
-        DecisionInternalFurtherDetail.E96
-    )]
+    [InlineData(ConsignmentDecision.NonAcceptable, null, new[] { "Other" }, DecisionCode.N04)]
     [InlineData(
         ConsignmentDecision.AcceptableIfChanneled,
         null,

--- a/tests/Deriver.Tests/Decisions/Finders/ChedDDecisionFinderTests.cs
+++ b/tests/Deriver.Tests/Decisions/Finders/ChedDDecisionFinderTests.cs
@@ -71,13 +71,7 @@ public class ChedDDecisionFinderTests
         DecisionCode.X00,
         DecisionInternalFurtherDetail.E96
     )]
-    [InlineData(
-        ConsignmentDecision.NonAcceptable,
-        null,
-        new[] { "Other" },
-        DecisionCode.X00,
-        DecisionInternalFurtherDetail.E96
-    )]
+    [InlineData(ConsignmentDecision.NonAcceptable, null, new[] { "Other" }, DecisionCode.N04)]
     [InlineData(
         ConsignmentDecision.AcceptableIfChanneled,
         null,

--- a/tests/Deriver.Tests/Decisions/Finders/ChedPDecisionFinderTests.cs
+++ b/tests/Deriver.Tests/Decisions/Finders/ChedPDecisionFinderTests.cs
@@ -63,13 +63,7 @@ public class ChedPDecisionFinderTests
         DecisionCode.X00,
         DecisionInternalFurtherDetail.E96
     )]
-    [InlineData(
-        ConsignmentDecision.NonAcceptable,
-        null,
-        new[] { "Other" },
-        DecisionCode.X00,
-        DecisionInternalFurtherDetail.E96
-    )]
+    [InlineData(ConsignmentDecision.NonAcceptable, null, new[] { "Other" }, DecisionCode.N04)]
     [InlineData(
         ConsignmentDecision.AcceptableForPrivateImport,
         null,


### PR DESCRIPTION
IT is possible to get both the ConsignmentDecision and NotAcceptableAction field populated.  This PR updates the code just to only evaluate the ConsignmentDecision if its an "acceptable" value, if its "not acceptable" it will then go and look at the "NotAcceptableAction"