### PR TITLE
Map the results of a decision to all decisions relating to the specified MRN

### DIFF
--- a/src/Deriver/Decisions/ClearanceDecisionBuilder.cs
+++ b/src/Deriver/Decisions/ClearanceDecisionBuilder.cs
@@ -26,6 +26,18 @@ public static class ClearanceDecisionBuilder
             CorrelationId = correlationIdGenerator.Generate(),
             ExternalVersionNumber = customsDeclaration.ClearanceRequest?.ExternalVersion,
             Items = BuildItems(customsDeclaration.ClearanceRequest!, decisions).ToArray(),
+            Results = decisions
+                .Select(x => new ClearanceDecisionResult
+                {
+                    ItemNumber = x.ItemNumber,
+                    ImportPreNotification = x.PreNotification?.Id,
+                    DocumentReference = x.DocumentReference,
+                    CheckCode = x.CheckCode,
+                    DecisionCode = x.DecisionCode.ToString(),
+                    DecisionReason = x.DecisionReason,
+                    InternalDecisionCode = x.InternalDecisionCode?.ToString(),
+                })
+                .ToArray(),
         };
     }
 

--- a/src/Deriver/Deriver.csproj
+++ b/src/Deriver/Deriver.csproj
@@ -15,7 +15,7 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Defra.TradeImportsDataApi.Api.Client" Version="0.29.0-pr-191.913" />
+    <PackageReference Include="Defra.TradeImportsDataApi.Api.Client" Version="0.29.0" />
     <PackageReference Include="Elastic.CommonSchema.Serilog" Version="8.12.3" />
     <PackageReference Include="Elastic.Serilog.Enrichers.Web" Version="8.12.3" />
     <PackageReference Include="Microsoft.AspNetCore.HeaderPropagation" Version="9.0.5" />

--- a/src/Deriver/Deriver.csproj
+++ b/src/Deriver/Deriver.csproj
@@ -15,7 +15,7 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Defra.TradeImportsDataApi.Api.Client" Version="0.28.0" />
+    <PackageReference Include="Defra.TradeImportsDataApi.Api.Client" Version="0.29.0-pr-191.913" />
     <PackageReference Include="Elastic.CommonSchema.Serilog" Version="8.12.3" />
     <PackageReference Include="Elastic.Serilog.Enrichers.Web" Version="8.12.3" />
     <PackageReference Include="Microsoft.AspNetCore.HeaderPropagation" Version="9.0.5" />

--- a/tests/Deriver.Tests/Decisions/ClearanceDecisionBuilderTests.BuildClearanceDecision_WithNoReasons.verified.txt
+++ b/tests/Deriver.Tests/Decisions/ClearanceDecisionBuilderTests.BuildClearanceDecision_WithNoReasons.verified.txt
@@ -31,5 +31,61 @@
         }
       ]
     }
+  ],
+  Results: [
+    {
+      ItemNumber: 1,
+      DocumentReference: docref_1_1,
+      CheckCode: 9115,
+      DecisionCode: C03
+    },
+    {
+      ItemNumber: 1,
+      DocumentReference: docref_1_2,
+      CheckCode: 9115,
+      DecisionCode: C03
+    },
+    {
+      ItemNumber: 1,
+      DocumentReference: docref_1_3,
+      CheckCode: 9115,
+      DecisionCode: C03
+    },
+    {
+      ItemNumber: 2,
+      DocumentReference: docref_2_1,
+      CheckCode: 9115,
+      DecisionCode: C03
+    },
+    {
+      ItemNumber: 2,
+      DocumentReference: docref_2_2,
+      CheckCode: 9115,
+      DecisionCode: C03
+    },
+    {
+      ItemNumber: 2,
+      DocumentReference: docref_2_3,
+      CheckCode: 9115,
+      DecisionCode: C03
+    },
+    {
+      ItemNumber: 3,
+      DocumentReference: docref_3_1,
+      CheckCode: 9115,
+      DecisionCode: C03
+    },
+    {
+      ItemNumber: 3,
+      DocumentReference: docref_3_2,
+      CheckCode: 9115,
+      DecisionCode: C03
+    },
+    {
+      ItemNumber: 3,
+      DocumentReference: docref_3_3,
+      CheckCode: 9115,
+      DecisionCode: C03
+    }
   ]
 }

--- a/tests/Deriver.Tests/Decisions/ClearanceDecisionBuilderTests.BuildClearanceDecision_WithNoReasons_AndPreviousDecision.verified.txt
+++ b/tests/Deriver.Tests/Decisions/ClearanceDecisionBuilderTests.BuildClearanceDecision_WithNoReasons_AndPreviousDecision.verified.txt
@@ -31,5 +31,61 @@
         }
       ]
     }
+  ],
+  Results: [
+    {
+      ItemNumber: 1,
+      DocumentReference: docref_1_1,
+      CheckCode: 9115,
+      DecisionCode: C03
+    },
+    {
+      ItemNumber: 1,
+      DocumentReference: docref_1_2,
+      CheckCode: 9115,
+      DecisionCode: C03
+    },
+    {
+      ItemNumber: 1,
+      DocumentReference: docref_1_3,
+      CheckCode: 9115,
+      DecisionCode: C03
+    },
+    {
+      ItemNumber: 2,
+      DocumentReference: docref_2_1,
+      CheckCode: 9115,
+      DecisionCode: C03
+    },
+    {
+      ItemNumber: 2,
+      DocumentReference: docref_2_2,
+      CheckCode: 9115,
+      DecisionCode: C03
+    },
+    {
+      ItemNumber: 2,
+      DocumentReference: docref_2_3,
+      CheckCode: 9115,
+      DecisionCode: C03
+    },
+    {
+      ItemNumber: 3,
+      DocumentReference: docref_3_1,
+      CheckCode: 9115,
+      DecisionCode: C03
+    },
+    {
+      ItemNumber: 3,
+      DocumentReference: docref_3_2,
+      CheckCode: 9115,
+      DecisionCode: C03
+    },
+    {
+      ItemNumber: 3,
+      DocumentReference: docref_3_3,
+      CheckCode: 9115,
+      DecisionCode: C03
+    }
   ]
 }

--- a/tests/Deriver.Tests/Decisions/ClearanceDecisionBuilderTests.BuildClearanceDecision_WithReasons.verified.txt
+++ b/tests/Deriver.Tests/Decisions/ClearanceDecisionBuilderTests.BuildClearanceDecision_WithReasons.verified.txt
@@ -40,5 +40,64 @@
         }
       ]
     }
+  ],
+  Results: [
+    {
+      ItemNumber: 1,
+      DocumentReference: fixed-1,
+      CheckCode: 9115,
+      DecisionCode: X00,
+      DecisionReason: Some Reason
+    },
+    {
+      ItemNumber: 1,
+      DocumentReference: fixed-2,
+      CheckCode: 9115,
+      DecisionCode: X00,
+      DecisionReason: Some Reason
+    },
+    {
+      ItemNumber: 1,
+      DocumentReference: fixed-3,
+      CheckCode: 9115,
+      DecisionCode: X00,
+      DecisionReason: Some Reason
+    },
+    {
+      ItemNumber: 2,
+      DocumentReference: fixed-4,
+      CheckCode: 9115,
+      DecisionCode: X00
+    },
+    {
+      ItemNumber: 2,
+      DocumentReference: fixed-5,
+      CheckCode: 9115,
+      DecisionCode: X00
+    },
+    {
+      ItemNumber: 2,
+      DocumentReference: fixed-6,
+      CheckCode: 9115,
+      DecisionCode: X00
+    },
+    {
+      ItemNumber: 3,
+      DocumentReference: fixed-7,
+      CheckCode: 9115,
+      DecisionCode: X00
+    },
+    {
+      ItemNumber: 3,
+      DocumentReference: fixed-8,
+      CheckCode: 9115,
+      DecisionCode: X00
+    },
+    {
+      ItemNumber: 3,
+      DocumentReference: fixed-9,
+      CheckCode: 9115,
+      DecisionCode: X00
+    }
   ]
 }

--- a/tests/Deriver.Tests/Decisions/ClearanceDecisionBuilderTests.cs
+++ b/tests/Deriver.Tests/Decisions/ClearanceDecisionBuilderTests.cs
@@ -31,9 +31,12 @@ public class ClearanceDecisionBuilderTests
             commodity.ItemNumber = i + 1;
             commodity.Checks = commodity.Checks!.Take(1).ToArray();
             commodity.Checks[0].CheckCode = "9115";
+
+            var documentReferenceCount = 1;
             foreach (var document in commodity.Documents!)
             {
                 document.DocumentCode = "9115";
+                document.DocumentReference!.Value = $"docref_{commodity.ItemNumber}_{documentReferenceCount}";
                 decisionResult.AddDecision(
                     customsDeclaration.MovementReferenceNumber,
                     commodity.ItemNumber!.Value!,
@@ -41,6 +44,8 @@ public class ClearanceDecisionBuilderTests
                     commodity.Checks[0].CheckCode,
                     DecisionCode.C03
                 );
+
+                documentReferenceCount++;
             }
         }
 
@@ -119,9 +124,12 @@ public class ClearanceDecisionBuilderTests
             commodity.ItemNumber = i + 1;
             commodity.Checks = commodity.Checks!.Take(1).ToArray();
             commodity.Checks[0].CheckCode = "9115";
+
+            var documentReferenceCount = 1;
             foreach (var document in commodity.Documents!)
             {
                 document.DocumentCode = "9115";
+                document.DocumentReference!.Value = $"docref_{commodity.ItemNumber}_{documentReferenceCount}";
                 decisionResult.AddDecision(
                     customsDeclaration.MovementReferenceNumber,
                     commodity.ItemNumber!.Value!,
@@ -129,6 +137,8 @@ public class ClearanceDecisionBuilderTests
                     commodity.Checks[0].CheckCode,
                     DecisionCode.C03
                 );
+
+                documentReferenceCount++;
             }
         }
 


### PR DESCRIPTION
Building on changes from PR https://github.com/DEFRA/trade-imports-data-api/pull/191, this PR includes the mapping of the internal decision information that currently powers the checks array.

This should give us the granular data we need.