### PR TITLE
CDMS-913 : Add E7x range for internal decision code

### DIFF
--- a/src/Deriver/Decisions/DecisionCode.cs
+++ b/src/Deriver/Decisions/DecisionCode.cs
@@ -25,11 +25,17 @@ public enum DecisionCode
 
 public enum DecisionInternalFurtherDetail
 {
-    E80, // No Match (Including Cancelled or Replaced or Deleted or Partially Rejected or Split Consignment)
+    E70, // No Match
+    E71, // Cancelled
+    E72, // Replaced
+    E73, // Deleted
+    E74, // Partially Rejected
+    E75, // Split Consignment
+    E80, // NO LONGER USED
     E85, // Missing PHSI check
     E86, // No HMI check
     E87, // No Documents
-    E88, // Cancelled or Replaced or Deleted
+    E88, // NO LONGER USED
     E89, // Item with document references where none are valid format
     E90, // No Decision Finder found
     E94, // IUU not indicated in PartTwo?.ControlAuthority?.IuuCheckRequired but "H224" requested in Items[]?.Checks[]?.CheckCode

--- a/src/Deriver/Decisions/DecisionService.cs
+++ b/src/Deriver/Decisions/DecisionService.cs
@@ -129,7 +129,7 @@ public class DecisionService(
                     checkCode,
                     DecisionCode.X00,
                     decisionReason: reason,
-                    internalDecisionCode: DecisionInternalFurtherDetail.E80
+                    internalDecisionCode: DecisionInternalFurtherDetail.E70
                 );
             }
         }
@@ -141,7 +141,7 @@ public class DecisionService(
                 noMatch.DocumentReference,
                 null,
                 DecisionCode.X00,
-                internalDecisionCode: DecisionInternalFurtherDetail.E80
+                internalDecisionCode: DecisionInternalFurtherDetail.E70
             );
         }
     }

--- a/src/Deriver/Decisions/Finders/ChedADecisionFinder.cs
+++ b/src/Deriver/Decisions/Finders/ChedADecisionFinder.cs
@@ -17,7 +17,7 @@ public class ChedADecisionFinder : DecisionFinder
             return new DecisionFinderResult(
                 DecisionCode.X00,
                 checkCode,
-                InternalDecisionCode: DecisionInternalFurtherDetail.E80
+                InternalDecisionCode: DecisionInternalFurtherDetail.E74
             );
         }
 

--- a/src/Deriver/Decisions/Finders/ChedDDecisionFinder.cs
+++ b/src/Deriver/Decisions/Finders/ChedDDecisionFinder.cs
@@ -19,7 +19,7 @@ public class ChedDDecisionFinder : DecisionFinder
             return new DecisionFinderResult(
                 DecisionCode.X00,
                 checkCode,
-                InternalDecisionCode: DecisionInternalFurtherDetail.E80
+                InternalDecisionCode: DecisionInternalFurtherDetail.E74
             );
         }
 

--- a/src/Deriver/Decisions/Finders/ChedPDecisionFinder.cs
+++ b/src/Deriver/Decisions/Finders/ChedPDecisionFinder.cs
@@ -21,7 +21,7 @@ public class ChedPDecisionFinder : DecisionFinder
             return new DecisionFinderResult(
                 DecisionCode.X00,
                 checkCode,
-                InternalDecisionCode: DecisionInternalFurtherDetail.E80
+                InternalDecisionCode: DecisionInternalFurtherDetail.E74
             );
         }
 

--- a/src/Deriver/Decisions/Finders/DecisionFinder.cs
+++ b/src/Deriver/Decisions/Finders/DecisionFinder.cs
@@ -11,21 +11,18 @@ public abstract class DecisionFinder : IDecisionFinder
 
     public DecisionFinderResult FindDecision(DecisionImportPreNotification notification, CheckCode? checkCode)
     {
-        if (
-            notification.Status == ImportNotificationStatus.Cancelled
-            || notification.Status == ImportNotificationStatus.Replaced
-            || notification.Status == ImportNotificationStatus.Deleted
-            || notification.Status == ImportNotificationStatus.SplitConsignment
-        )
+        return notification.Status switch
         {
-            return new DecisionFinderResult(
-                DecisionCode.X00,
-                checkCode,
-                InternalDecisionCode: DecisionInternalFurtherDetail.E80
-            );
-        }
-
-        return FindDecisionInternal(notification, checkCode);
+            ImportNotificationStatus.Cancelled => new DecisionFinderResult(DecisionCode.X00, checkCode,
+                InternalDecisionCode: DecisionInternalFurtherDetail.E71),
+            ImportNotificationStatus.Replaced => new DecisionFinderResult(DecisionCode.X00, checkCode,
+                InternalDecisionCode: DecisionInternalFurtherDetail.E72),
+            ImportNotificationStatus.Deleted => new DecisionFinderResult(DecisionCode.X00, checkCode,
+                InternalDecisionCode: DecisionInternalFurtherDetail.E73),
+            ImportNotificationStatus.SplitConsignment => new DecisionFinderResult(DecisionCode.X00, checkCode,
+                InternalDecisionCode: DecisionInternalFurtherDetail.E75),
+            _ => FindDecisionInternal(notification, checkCode)
+        };
     }
 
     protected static bool TryGetHoldDecision(DecisionImportPreNotification notification, out DecisionCode? decisionCode)

--- a/tests/Deriver.IntegrationTests/Endpoints/Decision/GetTests.Get_WhenFound_ShouldReturnContent.verified.txt
+++ b/tests/Deriver.IntegrationTests/Endpoints/Decision/GetTests.Get_WhenFound_ShouldReturnContent.verified.txt
@@ -19,7 +19,7 @@
               A Customs Declaration has been submitted however no matching CHEDPP(s) have been submitted to Port Health (for CHEDPP number(s) GBCHD2025.6244952). Please correct the CHEDPP number(s) entered on your customs declaration.
             ],
             decisionInternalFurtherDetail: [
-              E80
+              E70
             ]
           }
         ]
@@ -33,7 +33,7 @@
         checkCode: H218,
         decisionCode: X00,
         decisionReason: null,
-        internalDecisionCode: E80
+        internalDecisionCode: E70
       }
     ]
   }

--- a/tests/Deriver.IntegrationTests/Endpoints/Decision/PostTests.Get_WhenFound_ShouldReturnContent.verified.txt
+++ b/tests/Deriver.IntegrationTests/Endpoints/Decision/PostTests.Get_WhenFound_ShouldReturnContent.verified.txt
@@ -19,7 +19,7 @@
               A Customs Declaration has been submitted however no matching CHEDPP(s) have been submitted to Port Health (for CHEDPP number(s) GBCHD2025.6244952). Please correct the CHEDPP number(s) entered on your customs declaration.
             ],
             decisionInternalFurtherDetail: [
-              E80
+              E70
             ]
           }
         ]
@@ -33,7 +33,7 @@
         checkCode: H218,
         decisionCode: X00,
         decisionReason: null,
-        internalDecisionCode: E80
+        internalDecisionCode: E70
       }
     ]
   }

--- a/tests/Deriver.IntegrationTests/Endpoints/Decision/PostTests.Post_WhenFound_ShouldReturnContent.verified.txt
+++ b/tests/Deriver.IntegrationTests/Endpoints/Decision/PostTests.Post_WhenFound_ShouldReturnContent.verified.txt
@@ -19,7 +19,7 @@
               A Customs Declaration has been submitted however no matching CHEDPP(s) have been submitted to Port Health (for CHEDPP number(s) GBCHD2025.6244952). Please correct the CHEDPP number(s) entered on your customs declaration.
             ],
             decisionInternalFurtherDetail: [
-              E80
+              E70
             ]
           }
         ]
@@ -33,7 +33,7 @@
         checkCode: H218,
         decisionCode: X00,
         decisionReason: null,
-        internalDecisionCode: E80
+        internalDecisionCode: E70
       }
     ]
   }

--- a/tests/Deriver.Tests/Decisions/Finders/ChedADecisionFinderTests.cs
+++ b/tests/Deriver.Tests/Decisions/Finders/ChedADecisionFinderTests.cs
@@ -224,6 +224,6 @@ public class ChedADecisionFinderTests
         var result = sut.FindDecision(notification, null);
 
         result.DecisionCode.Should().Be(DecisionCode.X00);
-        result.InternalDecisionCode.Should().Be(DecisionInternalFurtherDetail.E80);
+        result.InternalDecisionCode.Should().Be(DecisionInternalFurtherDetail.E74);
     }
 }

--- a/tests/Deriver.Tests/Decisions/Finders/ChedDDecisionFinderTests.cs
+++ b/tests/Deriver.Tests/Decisions/Finders/ChedDDecisionFinderTests.cs
@@ -209,6 +209,6 @@ public class ChedDDecisionFinderTests
         var result = sut.FindDecision(notification, null);
 
         result.DecisionCode.Should().Be(DecisionCode.X00);
-        result.InternalDecisionCode.Should().Be(DecisionInternalFurtherDetail.E80);
+        result.InternalDecisionCode.Should().Be(DecisionInternalFurtherDetail.E74);
     }
 }

--- a/tests/Deriver.Tests/Decisions/Finders/ChedPDecisionFinderTests.cs
+++ b/tests/Deriver.Tests/Decisions/Finders/ChedPDecisionFinderTests.cs
@@ -187,6 +187,6 @@ public class ChedPDecisionFinderTests
         var result = sut.FindDecision(notification, null);
 
         result.DecisionCode.Should().Be(DecisionCode.X00);
-        result.InternalDecisionCode.Should().Be(DecisionInternalFurtherDetail.E80);
+        result.InternalDecisionCode.Should().Be(DecisionInternalFurtherDetail.E74);
     }
 }

--- a/tests/Deriver.Tests/Decisions/Finders/ChedPpPhsiDecisionFinderTests.cs
+++ b/tests/Deriver.Tests/Decisions/Finders/ChedPpPhsiDecisionFinderTests.cs
@@ -48,16 +48,16 @@ public class ChedPpPhsiDecisionFinderTests
 
     [Theory]
     [InlineData(ImportNotificationStatus.Amend, DecisionCode.X00, DecisionInternalFurtherDetail.E99)]
-    [InlineData(ImportNotificationStatus.Cancelled, DecisionCode.X00, DecisionInternalFurtherDetail.E80)]
-    [InlineData(ImportNotificationStatus.Deleted, DecisionCode.X00, DecisionInternalFurtherDetail.E80)]
+    [InlineData(ImportNotificationStatus.Cancelled, DecisionCode.X00, DecisionInternalFurtherDetail.E71)]
+    [InlineData(ImportNotificationStatus.Deleted, DecisionCode.X00, DecisionInternalFurtherDetail.E73)]
     [InlineData(ImportNotificationStatus.Draft, DecisionCode.X00, DecisionInternalFurtherDetail.E99)]
     [InlineData(ImportNotificationStatus.InProgress, DecisionCode.H02)]
     [InlineData(ImportNotificationStatus.Submitted, DecisionCode.H02)]
     [InlineData(ImportNotificationStatus.Modify, DecisionCode.X00, DecisionInternalFurtherDetail.E99)]
     [InlineData(ImportNotificationStatus.PartiallyRejected, DecisionCode.H01)]
     [InlineData(ImportNotificationStatus.Rejected, DecisionCode.N02)]
-    [InlineData(ImportNotificationStatus.Replaced, DecisionCode.X00, DecisionInternalFurtherDetail.E80)]
-    [InlineData(ImportNotificationStatus.SplitConsignment, DecisionCode.X00, DecisionInternalFurtherDetail.E80)]
+    [InlineData(ImportNotificationStatus.Replaced, DecisionCode.X00, DecisionInternalFurtherDetail.E72)]
+    [InlineData(ImportNotificationStatus.SplitConsignment, DecisionCode.X00, DecisionInternalFurtherDetail.E75)]
     public void DecisionFinderTest(
         string status,
         DecisionCode expectedCode,

--- a/tests/Deriver.Tests/Endpoints/Decision/GetTests.Get_WhenFound_AndDecisionDifferent_ShouldReturnContent.verified.txt
+++ b/tests/Deriver.Tests/Endpoints/Decision/GetTests.Get_WhenFound_AndDecisionDifferent_ShouldReturnContent.verified.txt
@@ -19,7 +19,7 @@
               A Customs Declaration has been submitted however no matching CHEDPP(s) have been submitted to Port Health (for CHEDPP number(s) GBCHD2025.6244952). Please correct the CHEDPP number(s) entered on your customs declaration.
             ],
             decisionInternalFurtherDetail: [
-              E80
+              E70
             ]
           }
         ]
@@ -33,7 +33,7 @@
         checkCode: H218,
         decisionCode: X00,
         decisionReason: null,
-        internalDecisionCode: E80
+        internalDecisionCode: E70
       }
     ]
   }

--- a/tests/Deriver.Tests/Endpoints/Decision/GetTests.Get_WhenFound_AndDecisionNotDifferent_ShouldReturnContent.verified.txt
+++ b/tests/Deriver.Tests/Endpoints/Decision/GetTests.Get_WhenFound_AndDecisionNotDifferent_ShouldReturnContent.verified.txt
@@ -19,7 +19,7 @@
               A Customs Declaration has been submitted however no matching CHEDPP(s) have been submitted to Port Health (for CHEDPP number(s) GBCHD2025.6244952). Please correct the CHEDPP number(s) entered on your customs declaration.
             ],
             decisionInternalFurtherDetail: [
-              E80
+              E70
             ]
           }
         ]
@@ -33,7 +33,7 @@
         checkCode: H218,
         decisionCode: X00,
         decisionReason: null,
-        internalDecisionCode: E80
+        internalDecisionCode: E70
       }
     ]
   }

--- a/tests/Deriver.Tests/Endpoints/Decision/PostTests.Get_WhenFound_ShouldReturnContent.verified.txt
+++ b/tests/Deriver.Tests/Endpoints/Decision/PostTests.Get_WhenFound_ShouldReturnContent.verified.txt
@@ -19,7 +19,7 @@
               A Customs Declaration has been submitted however no matching CHEDPP(s) have been submitted to Port Health (for CHEDPP number(s) GBCHD2025.6244952). Please correct the CHEDPP number(s) entered on your customs declaration.
             ],
             decisionInternalFurtherDetail: [
-              E80
+              E70
             ]
           }
         ]
@@ -33,7 +33,7 @@
         checkCode: H218,
         decisionCode: X00,
         decisionReason: null,
-        internalDecisionCode: E80
+        internalDecisionCode: E70
       }
     ]
   }


### PR DESCRIPTION
Added the following Internal decision codes:

E70, // No Match
E71, // Cancelled
E72, // Replaced
E73, // Deleted
E74, // Partially Rejected
E75, // Split Consignment