### PR TITLE
CDMS-953: Skip decisions when receiving import notification status with AMEND

### DIFF
--- a/src/Deriver/Consumers/ImportPreNotificationConsumer.cs
+++ b/src/Deriver/Consumers/ImportPreNotificationConsumer.cs
@@ -27,6 +27,16 @@ public class ImportPreNotificationConsumer(
             message.Resource?.ImportPreNotification.GetVersion()
         );
 
+        if (message.Resource?.ImportPreNotification.Status == ImportNotificationStatus.Amend)
+        {
+            logger.LogInformation(
+                "Skipping processing for notification {ResourceId} with version {Version} due to AMEND status",
+                message.ResourceId,
+                message.Resource?.ImportPreNotification.GetVersion()
+            );
+            return;
+        }
+
         var clearanceRequests = await GetClearanceRequests(message.ResourceId, cancellationToken);
         if (clearanceRequests.Count == 0)
         {


### PR DESCRIPTION
The processor is now persisting AMEND status import notifications in the Data API, causing them to be passed to the DD.

We do not want to re-run decisions when we receive these, so they are now discarded.