### PR TITLE
CDMS-906: Add nuget config for hotfix publishes

### DIFF
--- a/.github/workflows/publish-hotfix.yml
+++ b/.github/workflows/publish-hotfix.yml
@@ -7,6 +7,7 @@ permissions:
   id-token: write
   contents: write
   pull-requests: write
+  packages: read
 
 env:
   AWS_REGION: eu-west-2
@@ -22,6 +23,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Depth 0 required for branch-based versioning
+      - name: Update NuGet.config
+        run: |
+          dotnet nuget remove source defra --configfile ./NuGet.config
+          dotnet nuget add source --username USERNAME --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name defra "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" --configfile ./NuGet.config
       - name: Publish Hot Fix
         uses: DEFRA/cdp-build-action/build-hotfix@main
         with:


### PR DESCRIPTION
Currently if we try to run the hotfix pipeline it will fail because it cannot access the private NuGet repo.