### PR TITLE
Add decision reason for E71 (cancelled) and E72 (replaced)

### DIFF
--- a/src/Deriver/Decisions/Finders/DecisionFinder.cs
+++ b/src/Deriver/Decisions/Finders/DecisionFinder.cs
@@ -29,11 +29,13 @@ public abstract class DecisionFinder : IDecisionFinder
             ImportNotificationStatus.Cancelled => new DecisionFinderResult(
                 DecisionCode.X00,
                 checkCode,
+                DecisionReason: "This CHED has been cancelled. Update the customs declaration with a new reference.",
                 InternalDecisionCode: DecisionInternalFurtherDetail.E71
             ),
             ImportNotificationStatus.Replaced => new DecisionFinderResult(
                 DecisionCode.X00,
                 checkCode,
+                DecisionReason: "This CHED has been replaced. Update the customs declaration with a new reference.",
                 InternalDecisionCode: DecisionInternalFurtherDetail.E72
             ),
             ImportNotificationStatus.Deleted => new DecisionFinderResult(

--- a/tests/Deriver.Tests/Decisions/Finders/DecisionFinderTests.FindDecision_status=CANCELLED_hasPartTwo=True.verified.txt
+++ b/tests/Deriver.Tests/Decisions/Finders/DecisionFinderTests.FindDecision_status=CANCELLED_hasPartTwo=True.verified.txt
@@ -1,0 +1,8 @@
+﻿{
+  DecisionCode: X00,
+  CheckCode: {
+    Value: value
+  },
+  DecisionReason: This CHED has been cancelled. Update the customs declaration with a new reference.,
+  InternalDecisionCode: E71
+}

--- a/tests/Deriver.Tests/Decisions/Finders/DecisionFinderTests.FindDecision_status=DELETED_hasPartTwo=True.verified.txt
+++ b/tests/Deriver.Tests/Decisions/Finders/DecisionFinderTests.FindDecision_status=DELETED_hasPartTwo=True.verified.txt
@@ -1,0 +1,7 @@
+﻿{
+  DecisionCode: X00,
+  CheckCode: {
+    Value: value
+  },
+  InternalDecisionCode: E73
+}

--- a/tests/Deriver.Tests/Decisions/Finders/DecisionFinderTests.FindDecision_status=IGNORED_hasPartTwo=False.verified.txt
+++ b/tests/Deriver.Tests/Decisions/Finders/DecisionFinderTests.FindDecision_status=IGNORED_hasPartTwo=False.verified.txt
@@ -1,0 +1,7 @@
+﻿{
+  DecisionCode: X00,
+  CheckCode: {
+    Value: value
+  },
+  InternalDecisionCode: E88
+}

--- a/tests/Deriver.Tests/Decisions/Finders/DecisionFinderTests.FindDecision_status=REPLACED_hasPartTwo=True.verified.txt
+++ b/tests/Deriver.Tests/Decisions/Finders/DecisionFinderTests.FindDecision_status=REPLACED_hasPartTwo=True.verified.txt
@@ -1,0 +1,8 @@
+﻿{
+  DecisionCode: X00,
+  CheckCode: {
+    Value: value
+  },
+  DecisionReason: This CHED has been replaced. Update the customs declaration with a new reference.,
+  InternalDecisionCode: E72
+}

--- a/tests/Deriver.Tests/Decisions/Finders/DecisionFinderTests.FindDecision_status=SPLIT_CONSIGNMENT_hasPartTwo=True.verified.txt
+++ b/tests/Deriver.Tests/Decisions/Finders/DecisionFinderTests.FindDecision_status=SPLIT_CONSIGNMENT_hasPartTwo=True.verified.txt
@@ -1,0 +1,7 @@
+﻿{
+  DecisionCode: X00,
+  CheckCode: {
+    Value: value
+  },
+  InternalDecisionCode: E75
+}

--- a/tests/Deriver.Tests/Decisions/Finders/DecisionFinderTests.cs
+++ b/tests/Deriver.Tests/Decisions/Finders/DecisionFinderTests.cs
@@ -1,0 +1,69 @@
+using Defra.TradeImportsDecisionDeriver.Deriver.Decisions;
+using Defra.TradeImportsDecisionDeriver.Deriver.Decisions.Finders;
+
+namespace Defra.TradeImportsDecisionDeriver.Deriver.Tests.Decisions.Finders;
+
+public class DecisionFinderTests
+{
+    [Theory]
+    [InlineData(ImportNotificationStatus.Cancelled, true)]
+    [InlineData(ImportNotificationStatus.Replaced, true)]
+    [InlineData(ImportNotificationStatus.Deleted, true)]
+    [InlineData(ImportNotificationStatus.SplitConsignment, true)]
+    [InlineData("IGNORED", false)]
+    public async Task FindDecision(string status, bool hasPartTwo)
+    {
+        var subject = new FixtureFinder();
+
+        var result = subject.FindDecision(
+            new DecisionImportPreNotification
+            {
+                Id = "id",
+                Status = status,
+                HasPartTwo = hasPartTwo,
+            },
+            new CheckCode { Value = "value" }
+        );
+
+        await Verify(result).UseParameters(status, hasPartTwo);
+    }
+
+    [Fact]
+    public void FindDecision_FindDecisionInternal_Throws()
+    {
+        var subject = new FixtureFinder();
+
+        var act = () =>
+            subject.FindDecision(
+                new DecisionImportPreNotification
+                {
+                    Id = "id",
+                    Status = "IGNORED",
+                    HasPartTwo = true,
+                },
+                new CheckCode { Value = "value" }
+            );
+
+        act.Should().Throw<NotImplementedException>();
+    }
+
+    private class FixtureFinder : DecisionFinder
+    {
+        protected override DecisionFinderResult FindDecisionInternal(
+            DecisionImportPreNotification notification,
+            CheckCode? checkCode
+        )
+        {
+            throw new NotImplementedException();
+        }
+
+        public override bool CanFindDecision(
+            DecisionImportPreNotification notification,
+            CheckCode? checkCode,
+            string? documentCode
+        )
+        {
+            throw new NotImplementedException();
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a text description (the reason) alongside the decision code. This will then allow the UI to display the appropriate message to users.