### PR TITLE
Update GMR error message so length does not break 512 limit

### DIFF
--- a/Defra.TradeImportsDecisionDeriver.sln.DotSettings
+++ b/Defra.TradeImportsDecisionDeriver.sln.DotSettings
@@ -1,8 +1,11 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=ched/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=chedpp/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=deriver/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=gmrs/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=ipaffs/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=iuuna/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=iuuok/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=mrns/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/UserDictionary/Words/=phsi/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=phsi/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=taric/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/Deriver/Decisions/DecisionReasonBuilder.cs
+++ b/src/Deriver/Decisions/DecisionReasonBuilder.cs
@@ -15,14 +15,8 @@ public static class DecisionReasonBuilder
     public static string AnimalHealthErrorMessage(string chedType, string chedNumbers) =>
         $"A Customs Declaration has been submitted however no matching {chedType}(s) have been submitted to Animal Health for {chedType} number(s) {chedNumbers}.";
 
-    public static string GmsErrorMessage(
-        string? ucr,
-        int? itemNumber,
-        decimal? netMass,
-        string? taricCode,
-        string? goodsDescription
-    ) =>
-        $"A Customs Declaration with a GMS product has been selected for HMI inspection. If using PEACH then raise a GMS application. If using IPAFFS then create a CHEDPP and amend your licence to reference it. If a CHEDPP exists amend your licence to reference it. Failure to do so will delay your Customs release. The selected item was declared on a Customs Declaration with a Declaration UCR of {ucr} and Item Number {itemNumber} with a weight of {netMass} and is TARIC Code {taricCode} with a description of {goodsDescription}.";
+    public static string GmsErrorMessage(int? itemNumber, string? taricCode, string? goodsDescription) =>
+        $"Item number {itemNumber} has been selected for HMI inspection. In IPAFFS either create a new CHEDPP with this item or amend an existing CHEDPP to include this item. The item selected has a TARIC code of {taricCode} and a description of {goodsDescription}.";
 
     public static List<string> Build(
         ClearanceRequest clearanceRequest,
@@ -34,7 +28,7 @@ public static class DecisionReasonBuilder
         var reasons = new List<string>();
 
         HandleNoLinkedNotifications(item, maxDecisionResult, documentDecisions, reasons);
-        HandleHmiGmsDecisionReason(clearanceRequest, item, maxDecisionResult, reasons);
+        HandleHmiGmsDecisionReason(item, maxDecisionResult, reasons);
 
         return reasons;
     }
@@ -92,7 +86,6 @@ public static class DecisionReasonBuilder
     }
 
     private static void HandleHmiGmsDecisionReason(
-        ClearanceRequest clearanceRequest,
         Commodity item,
         DocumentDecisionResult maxDecisionResult,
         List<string> reasons
@@ -100,15 +93,7 @@ public static class DecisionReasonBuilder
     {
         if (maxDecisionResult is { DecisionCode: DecisionCode.X00, CheckCode: "H220" })
         {
-            reasons.Add(
-                GmsErrorMessage(
-                    clearanceRequest.DeclarationUcr,
-                    item.ItemNumber,
-                    item.NetMass,
-                    item.TaricCommodityCode,
-                    item.GoodsDescription
-                )
-            );
+            reasons.Add(GmsErrorMessage(item.ItemNumber, item.TaricCommodityCode, item.GoodsDescription));
         }
     }
 

--- a/tests/Deriver.Tests/Decisions/DecisionReasonBuilderTests.cs
+++ b/tests/Deriver.Tests/Decisions/DecisionReasonBuilderTests.cs
@@ -130,15 +130,7 @@ public class DecisionReasonBuilderTests
         result.Count.Should().Be(1);
         result[0]
             .Should()
-            .Be(
-                DecisionReasonBuilder.GmsErrorMessage(
-                    cr.DeclarationUcr,
-                    item.ItemNumber,
-                    item.NetMass,
-                    item.TaricCommodityCode,
-                    item.GoodsDescription
-                )
-            );
+            .Be(DecisionReasonBuilder.GmsErrorMessage(item.ItemNumber, item.TaricCommodityCode, item.GoodsDescription));
     }
 
     [Fact]
@@ -166,15 +158,7 @@ public class DecisionReasonBuilderTests
         result.Count.Should().Be(1);
         result[0]
             .Should()
-            .Be(
-                DecisionReasonBuilder.GmsErrorMessage(
-                    cr.DeclarationUcr,
-                    item.ItemNumber,
-                    item.NetMass,
-                    item.TaricCommodityCode,
-                    item.GoodsDescription
-                )
-            );
+            .Be(DecisionReasonBuilder.GmsErrorMessage(item.ItemNumber, item.TaricCommodityCode, item.GoodsDescription));
     }
 
     [Fact]


### PR DESCRIPTION
Previous error message was too long for HMRC. This PR reduces length so it can be processed.