### PR TITLE
CDMS-1341 - Fix CommodityQuantityCheckDecisionRule short-circuit condition

### DIFF
--- a/src/Deriver/Decisions/DecisionEngine/DecisionRules/CommodityQuantityCheckDecisionRule.cs
+++ b/src/Deriver/Decisions/DecisionEngine/DecisionRules/CommodityQuantityCheckDecisionRule.cs
@@ -12,7 +12,7 @@ public sealed class CommodityQuantityCheckDecisionRule(IOptions<DecisionRulesOpt
     {
         var result = next(context);
 
-        if (!result.Code.IsReleaseOrHold() || !context.Level2Succeeded == false)
+        if (!result.Code.IsReleaseOrHold() || context.Level2Succeeded == false)
         {
             return result;
         }


### PR DESCRIPTION
Corrects a logical error where the rule would previously short-circuit if 'Level2Succeeded' was true. The updated condition ensures the rule proceeds when Level 2 is successful and short-circuits only if Level 2 has failed.